### PR TITLE
Refactor pattern module into new crate

### DIFF
--- a/bc-envelope-pattern/Cargo.toml
+++ b/bc-envelope-pattern/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bc-envelope-pattern"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bc-envelope = { path = ".." }
+regex = "1.11.1"
+known-values = "^0.6.0"
+dcbor = { version = "^0.21.0", features = ["anyhow", "multithreaded"] }
+bc-components = "^0.23.0"
+hex = "^0.4.3"
+
+[dev-dependencies]
+hex-literal = "^0.4.1"
+indoc = "^2.0.0"
+bc-rand = "^0.4.0"
+anyhow = "^1.0.0"
+
+[features]
+default = ["signature", "encrypt", "compress", "known_value", "types"]
+signature = []
+encrypt = []
+compress = []
+known_value = []
+types = []
+

--- a/bc-envelope-pattern/src/lib.rs
+++ b/bc-envelope-pattern/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod pattern;
+
+pub use bc_envelope::{Envelope, EdgeType};
+pub use pattern::{Matcher, Path, Pattern, Greediness};

--- a/bc-envelope-pattern/src/pattern/AGENTS.md
+++ b/bc-envelope-pattern/src/pattern/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+Finish the `pattern` subsystem so that `RepeatPattern` and `CapturePattern` are fully supported, and all crate tests pass.
+
+What follows is everything you need:
+
+# High-level goal
+
+Turn the existing pattern DSL into a complete back-tracking engine that supports
+
+- Equivalent functionality to regex `*`, `+`, `?`, `{n,m}` quantifiers (greedy, lazy, possessive)
+- Named captures (placeholder for now – just emit paths).
+
+# Big picture
+
+We compile the Pattern AST to a small Thompson-NFA-like byte-code (in `src/pattern/vm.rs`) and execute it against an Envelope tree. All mutations are additive; existing APIs continue to work.
+
+# Tests
+
+These tests are hanging:
+
+```bash
+cargo test --test 'pattern_tests_repeat'
+```
+
+This runs all pattern tests, including the hanging ones:
+
+```bash
+cargo test --test 'pattern_tests*'
+```

--- a/bc-envelope-pattern/src/pattern/REPEAT_STRATEGIES.md
+++ b/bc-envelope-pattern/src/pattern/REPEAT_STRATEGIES.md
@@ -1,0 +1,209 @@
+You:
+
+In regexes, explain the difference between “greedy” and “non-greedy” quantifiers; particularly how they choose their stopping condition.
+
+ChatGPT:
+
+Thought for 5 seconds
+
+A greedy quantifier (`*`, `+`, `?`, `{m,n}`) grabs as many characters as it can on its first pass, then backs off one character at a time only if the rest of the pattern fails to match. Its stopping condition is therefore “no more characters can be given back and still satisfy the overall pattern.” In effect it asks, “How far can I push the cursor to the right and still succeed?”
+
+A non-greedy (lazy or reluctant) quantifier (`*?`, `+?`, `??`, `{m,n}?`) does the mirror image. It starts by taking the minimum it is allowed—just enough to satisfy its own lower bound—then grows one character at a time only if the remainder of the pattern fails. Its stopping condition is “the earliest point at which the rest of the pattern succeeds.” It asks, “What is the first place I can stop and still succeed?”
+
+Consider the text `<b>bold</b>` and the pattern `<.*>`.
+
+*Greedy* `.*` eats everything up to the final `>`, so the match is `<b>bold</b>`.
+*Non-greedy* `.*?` stops at the first `>` that lets the whole pattern succeed, matching `<b>`.
+
+Both quantifiers rely on the same backtracking engine; they simply begin the search from opposite ends of the allowable range and walk toward the other end until success is possible.
+
+You:
+
+So if I am implementing a “repeat” operator in a regex-like DSL, in addition to specifying the pattern it matches and its n,m cardinality,I need it to have a “greedy” flag?
+
+ChatGPT:
+
+Thought for 5 seconds
+
+Yes. Cardinality alone (`min … max`) says only how many repeats are allowed. Greediness (or laziness) says **in what order to try those counts** when the engine explores its search space. A practical data structure therefore needs at least three fields:
+
+```lua
+pattern to repeat
+min_reps
+max_reps   // often ∞
+greedy     // true → try max→min, false → try min→max
+```
+
+In a backtracking VM you simply loop over the candidate repeat counts in the chosen order, pushing the engine state for each attempt. With a Thompson-style NFA you insert ε-transitions for “take another copy” and “proceed,” then rank the transitions so the greedy branch is consulted first (or last, for lazy). Either way, the boolean (or an enum if you also support possessive quantifiers) is essential if you want both behaviors exposed in your DSL; without it you’re hard-coding one policy.
+
+You:
+
+Can a `repeat` pattern matcher decide by itself whether it has reached its end condition, or does it need to be embedded in an engine that has a larger view of the sequence in which the `repeat` matcher is embedded?
+
+ChatGPT:
+
+Thought for 8 seconds
+
+A repeat node can’t know on its own when to stop, because its correct stopping point is defined **by whatever comes next in the pattern**. Greedy or lazy, it must hand the engine a series of “candidate endpoints” and wait to be told which one lets the rest of the pattern succeed.
+
+---
+
+### Why the quantifier can’t decide in isolation
+
+-   **Greedy case** – The quantifier tries the largest span first, but it stops backing off only when *the following sub-expression* finally matches.
+
+-   **Lazy case** – The quantifier offers the smallest span first, but it keeps growing only until *the following sub-expression* matches.
+
+
+Either way the repeat node can’t tell, by inspecting just the characters it has consumed, whether more or fewer repeats are needed; it needs feedback from the next part of the regex.
+
+---
+
+### What this means for an implementation
+
+1.  **Backtracking engines (PCRE-style).**
+    The repeat node is just a loop that pushes successive engine states (`pos, rep_count`) in the order dictated by its greediness flag. The overall engine pops those states while trying the rest of the pattern. Only the engine—as the global orchestrator—knows when a given state yields a full match.
+
+2.  **Thompson-NFA engines (Rust’s `regex`, RE2, etc.).**
+    At compile time the quantifier is expanded into ε-transitions: one edge that stays in the loop, one that proceeds. Run-time matching is then just NFA traversal, but that traversal includes states produced by the *entire* pattern, so the decision is still global—just implicit in the state machine.
+
+3.  **DFA compilation.**
+    The whole pattern (including the repeat) is determinized into a big automaton. At run time each input character drives a single state transition, so there’s no explicit “decision” inside the repeat node. But that’s only because the repeat was already fused with what comes after it during determinization—the broader view happened earlier.
+
+4.  **Parser-combinator or PEG style.**
+    Same story: the combinator for `repeat` yields matches in an order (max-to-min or min-to-max). The enclosing sequence combinator attempts the rest; only that outer context can accept or reject each attempt.
+
+
+---
+
+### Exception: possessive quantifiers
+
+A **possessive** quantifier (`*+`, `++`, `{m,n}+` in PCRE/Java) *does* decide unilaterally: it consumes as much as it can and refuses to backtrack. That works only because its contract is “never give characters back.”
+
+---
+
+**Bottom line:** a normal (backtracking) repeat operator must be embedded in, or compiled together with, an engine that has visibility beyond the repeated sub-pattern. Only the overall engine can say, “This endpoint is the one that lets the whole pattern succeed.”
+
+You:
+
+Can a repeat matcher operate correctly if it is given the “terminator pattern,” I.e., the pattern which would be next in the sequence of which the `repeat` matcher is the predecessor?
+
+ChatGPT:
+
+Thought for 11 seconds
+
+It can solve some—but not all—of the stopping problem.
+
+Give the repeat node a reference to the pattern that follows it (“the terminator”), and it can run an inner loop:
+
+1.  Consume according to its min/max and greediness.
+
+2.  At each candidate endpoint, hand control to that terminator matcher.
+
+3.  If the terminator matches, stop; otherwise continue (back-off for greedy, grow for lazy).
+
+
+That is enough for straightforward tails such as a fixed string or a simple sub-regex. It is how many engines optimise something like `.*?END`: the `.*?` node keeps jumping to the next occurrence of `E`, then asks “does `ND` match here?” No global engine is needed beyond that handshake.
+
+But the moment the tail itself contains branching, back-references, look-arounds, or further quantifiers, the repeat node can no longer be sure the terminator’s success really means “the whole rest of the pattern will succeed.” Example:
+
+```less
+a* ( b  |  ac )
+```
+
+If the text is `aaac`, the terminator seen by `a*` is `(b|ac)`. The first time `ac` matches, the overall pattern succeeds; the first time `b` matches, it fails. The repeat node would have to explore both branches of the alternation to know which outcome matters—effectively re-implementing the regex VM inside itself. At that point you have reinvented the central engine.
+
+So in practice:
+
+-   **Yes** – passing the next matcher lets a repeat node settle questions that depend only on that immediate tail, and it can be an efficient micro-optimisation.
+
+-   **No** – for full regex semantics, you still need an orchestrator with visibility beyond the terminator, because later constructs can retroactively make the “correct” endpoint earlier or later than the terminator alone reveals.
+
+
+The usual solution is what NFAs and backtracking VMs already do: compile the repeat and everything after it into a single graph of states, then let the generic engine explore that graph. That keeps each node simple while guaranteeing correctness for every construct the language allows.
+
+You:
+
+Explain “NFA” and “VM” in this context.
+
+ChatGPT:
+
+Thought for 4 seconds
+
+An **NFA engine** turns the regex into a nondeterministic finite-automaton graph: every node represents “where we are in the pattern,” and edges are labeled with either a literal character or ε (an empty move). At run time the engine keeps a set (often a bit-vector) of all states that could be active after each input character. Because all possibilities are advanced in lockstep, it never rewinds the text: worst-case time is linear in input length. Greedy vs. lazy is encoded by putting the ε edge that means “stay in the loop” before or after the ε edge that means “proceed,” so the subset construction naturally prefers one path over the other. Libraries like RE2 and Rust’s `regex` work this way.
+
+A **VM engine** (backtracking virtual machine) compiles the pattern into a little bytecode—`MATCH_CHAR`, `JUMP`, `SPLIT`, `SAVE_POS`, etc.—and then interprets it with an explicit stack of backtrack frames. When a `SPLIT` is hit (e.g., at the mouth of a `*` loop or an alternation), the VM pushes the secondary branch and continues down the primary one. If that primary path fails later, it pops a frame and resumes from the saved program counter and input position. Greedy vs. lazy is just the order in which the two branch addresses are placed in the bytecode. This design handles captures, back-references, and look-arounds but can blow up exponentially on pathological input (the “Regex DoS”). Perl, PCRE, Java, and .NET use this style.
+
+So, “NFA” here means “simulate all paths simultaneously with a state-set”; “VM” means “run a backtracking bytecode interpreter that explores paths one at a time.”
+
+You:
+
+Is there an existing Rust crate that facilitates the construction of regex-like matching engines that can be used on my own structure with my own matcher? My structure is a tree and a match pattern may return more than one path through the tree.
+
+ChatGPT:
+
+Thought for 1m 14s
+
+For arbitrary data structures you won’t find a “drop-in” analogue of `regex`—every Rust regex crate ultimately assumes a **linear `&[u8]` input**. The moment your “alphabet” is *paths through a tree* you leave that territory and have three realistic options:
+
+**1\. Expose your own tree as a Tree-sitter grammar and use its query engine.**
+`tree-sitter` compiles an S-expression query into an NFA that walks a concrete-syntax tree and returns *all* matches via a `QueryCursor`; a single pattern can therefore yield many distinct paths. The crate is pure Rust bindings, so you can drive it entirely inside your codebase and feed the cursor’s captures back into your application logic[docs.rs](https://docs.rs/tree-sitter). The trade-off is that you must write a small grammar (or auto-generate one) that maps each of your node kinds to a Tree-sitter symbol, but once that’s done you get a robust, battle-tested matcher with lazy/greedy captures, predicates and naming.
+
+**2\. Build a bespoke automaton on top of `tree-automata`.**
+The `tree-automata` crate gives you bottom-up and alternating tree automata primitives in Rust[github.com](https://github.com/regular-pv/tree-automata). You define states and transition functions for each node kind; the library executes the automaton and tells you which states (i.e., which pattern alternatives) are reachable at every node. Because the data model is *trees* rather than byte streams, this is the closest conceptual match to “regex for trees,” but the API is low-level—you will have to translate your DSL’s `repeat/alternation/sequence` operators into explicit automaton states yourself.
+
+**3\. Reuse the linear automata machinery and map your tree to a stream.**
+`regex-automata` exposes the raw Thompson NFA, Pike VM and DFA builders that power Rust’s `regex` crate[github.com](https://github.com/BurntSushi/regex-automata). If you can linearise each root-to-leaf path into a token stream (e.g., encode node-type IDs into bytes) you can compile your DSL to that NFA and run it over every path. It’s fast, well-tested and supports non-greedy quantifiers, but you lose direct access to sibling/ancestor relationships unless you encode them into the stream.
+
+---
+
+**Reality check**
+
+-   There is no off-the-shelf crate that lets you plug in “my matcher returns zero-or-more child paths” and automatically handles greedy/lazy backtracking.
+
+-   The forum discussion on “generic regex” reached the same conclusion: once you leave byte strings you either adopt a parser-combinator or roll a custom automaton layer yourself[users.rust-lang.org](https://users.rust-lang.org/t/generic-regex/105546).
+
+
+**Recommendation**
+
+If you want something working this month, wrap your tree in a minimal Tree-sitter grammar and write your DSL as Tree-sitter queries. You’ll get multi-path matches, capture groups, a proven engine and zero concern about exponential blow-ups. When you eventually need deeper static guarantees or custom optimisation, use `tree-automata` as the foundation for a dedicated engine; its state-machine model maps cleanly to the semantics you’ve been designing.
+
+You:
+
+Will going the Tree-sitter route also handle captures and the like?
+
+ChatGPT:
+
+Thought for 30 seconds
+
+Yes. Tree-sitter’s query language was designed around **named captures**, so when you move your DSL to Tree-sitter you get capture semantics “for free.”
+
+-   In a pattern you mark any node you want to extract with an `@capture_name`, for example
+    `(function_definition name:(identifier) @func)`.
+
+-   At run-time you compile the S-expression patterns into a `Query`, create a `QueryCursor`, and stream either **matches** (groups of captures that satisfied one pattern) or the captures themselves. Each capture arrives as `(Node, capture_index)`; you can look the name up with `query.capture_names()` and turn the node into text with `node.utf8_text(bytes)`.
+
+
+Rust sketch:
+
+```rust
+let query_src = r#"
+  (call_expression
+     function: (identifier) @func
+     arguments: (argument_list (identifier) @arg)*)"#;
+
+let query  = Query::new(my_lang(), query_src)?;
+let mut qc = QueryCursor::new();
+
+for m in qc.matches(&query, root_node, source.as_bytes()) {
+    for cap in m.captures {
+        let name = query.capture_names()[cap.index as usize];
+        let text = cap.node.utf8_text(source.as_bytes())?;
+        println!("{name}: {text}");
+    }
+}
+```
+
+The API also lets you inspect **capture quantifiers** (`query.capture_quantifiers`) and iterate over a flat stream of captures (`QueryCursor::captures`) when you don’t care which pattern matched first[docs.rs](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Query.html)[docs.rs](https://docs.rs/tree-sitter/latest/tree_sitter/struct.QueryCursor.html?utm_source=chatgpt.com).
+
+Tree-sitter deliberately omits PCRE-style back-references, but for ordinary “grab this subtree (or these repeated subtrees) as a capture” it covers everything you need, without any extra plumbing on your side.

--- a/bc-envelope-pattern/src/pattern/compile.rs
+++ b/bc-envelope-pattern/src/pattern/compile.rs
@@ -1,0 +1,18 @@
+use crate::pattern::{Pattern, vm::Instr};
+
+/// Any pattern that knows how to append its byte-code to `code`.
+pub trait Compilable {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>);
+}
+
+/// Helper you can reuse in many impls: push self into `literals` and
+/// emit a single MatchPredicate.
+pub fn compile_as_atomic(
+    pat: &Pattern,
+    code: &mut Vec<Instr>,
+    lits: &mut Vec<Pattern>,
+) {
+    let idx = lits.len();
+    lits.push(pat.clone());
+    code.push(Instr::MatchPredicate(idx));
+}

--- a/bc-envelope-pattern/src/pattern/greediness.rs
+++ b/bc-envelope-pattern/src/pattern/greediness.rs
@@ -1,0 +1,10 @@
+/// Greediness (a.k.a. laziness / possessiveness) for quantifiers.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Greediness {
+    /// Grabs as many repetitions as possible, then backtracks if the rest of the pattern cannot match.
+    Greedy,
+    /// Starts with as few repetitions as possible, adding more only if the rest of the pattern cannot match.
+    Lazy,
+    /// Grabs as many repetitions as possible and never backtracks; if the rest of the pattern cannot match, the whole match fails.
+    Possessive,
+}

--- a/bc-envelope-pattern/src/pattern/leaf/array_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/array_pattern.rs
@@ -1,0 +1,106 @@
+use std::ops::RangeInclusive;
+
+use crate::{
+    pattern::{compile_as_atomic, leaf::LeafPattern, vm::Instr, Compilable, Matcher, Path}, Envelope, Pattern
+};
+
+/// Pattern for matching arrays.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum ArrayPattern {
+    /// Matches any array.
+    Any,
+    /// Matches arrays with a specific count of elements.
+    Count(RangeInclusive<usize>),
+}
+
+impl ArrayPattern {
+    /// Creates a new `ArrayPattern` that matches any array.
+    pub fn any() -> Self { ArrayPattern::Any }
+
+    /// Creates a new `ArrayPattern` that matches arrays with a specific count
+    /// of elements.
+    pub fn range_count(range: RangeInclusive<usize>) -> Self {
+        ArrayPattern::Count(range)
+    }
+
+    /// Creates a new `ArrayPattern` that matches arrays with exactly the
+    /// specified count of elements.
+    pub fn count(count: usize) -> Self { ArrayPattern::Count(count..=count) }
+}
+
+impl Matcher for ArrayPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if let Some(array) = envelope.subject().as_array() {
+            match self {
+                ArrayPattern::Any => vec![vec![envelope.clone()]],
+                ArrayPattern::Count(range) => {
+                    if range.contains(&array.len()) {
+                        vec![vec![envelope.clone()]]
+                    } else {
+                        vec![]
+                    }
+                }
+            }
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for ArrayPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Array(
+                self.clone(),
+            )),
+            code,
+            literals,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dcbor::prelude::*;
+
+    use super::*;
+    use bc_envelope::Envelope;
+
+    #[test]
+    fn test_array_pattern_any() {
+        // Create a CBOR array directly
+        let cbor_array = vec![1, 2, 3].to_cbor();
+        let envelope = Envelope::new(cbor_array);
+        let pattern = ArrayPattern::any();
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with non-array envelope
+        let text_envelope = Envelope::new("test");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_array_pattern_count() {
+        // Create a CBOR array directly
+        let cbor_array = vec![1, 2, 3].to_cbor();
+        let envelope = Envelope::new(cbor_array);
+
+        // Test exact count
+        let pattern = ArrayPattern::count(3);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test count range
+        let pattern = ArrayPattern::range_count(2..=4);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test count mismatch
+        let pattern = ArrayPattern::count(5);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/bool_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/bool_pattern.rs
@@ -1,0 +1,51 @@
+use crate::{
+    pattern::{compile_as_atomic, leaf::LeafPattern, vm::Instr, Compilable, Matcher, Path}, Envelope, Pattern
+};
+
+/// Pattern for matching boolean values.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum BoolPattern {
+    /// Matches any boolean value.
+    Any,
+    /// Matches the specific boolean value.
+    Exact(bool),
+}
+
+impl BoolPattern {
+    /// Creates a new `BoolPattern` that matches any boolean value.
+    pub fn any() -> Self { BoolPattern::Any }
+
+    /// Creates a new `BoolPattern` that matches the specific boolean value.
+    pub fn exact(value: bool) -> Self { BoolPattern::Exact(value) }
+}
+
+impl Matcher for BoolPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        let is_hit =
+            envelope
+                .extract_subject::<bool>()
+                .ok()
+                .is_some_and(|value| match self {
+                    BoolPattern::Any => true,
+                    BoolPattern::Exact(want) => value == *want,
+                });
+
+        if is_hit {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for BoolPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Bool(
+                self.clone(),
+            )),
+            code,
+            literals,
+        );
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/byte_string_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/byte_string_pattern.rs
@@ -1,0 +1,170 @@
+use crate::{
+    pattern::{compile_as_atomic, leaf::LeafPattern, vm::Instr, Compilable, Matcher, Path}, Envelope, Pattern
+};
+
+/// Pattern for matching byte string values.
+#[derive(Debug, Clone)]
+pub enum ByteStringPattern {
+    /// Matches any byte string.
+    Any,
+    /// Matches the specific byte string.
+    Exact(Vec<u8>),
+    /// Matches the binary regular expression for a byte string.
+    BinaryRegex(regex::bytes::Regex),
+}
+
+impl PartialEq for ByteStringPattern {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ByteStringPattern::Any, ByteStringPattern::Any) => true,
+            (ByteStringPattern::Exact(a), ByteStringPattern::Exact(b)) => {
+                a == b
+            }
+            (
+                ByteStringPattern::BinaryRegex(a),
+                ByteStringPattern::BinaryRegex(b),
+            ) => a.as_str() == b.as_str(),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ByteStringPattern {}
+
+impl std::hash::Hash for ByteStringPattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            ByteStringPattern::Any => {
+                0u8.hash(state);
+            }
+            ByteStringPattern::Exact(s) => {
+                1u8.hash(state);
+                s.hash(state);
+            }
+            ByteStringPattern::BinaryRegex(regex) => {
+                2u8.hash(state);
+                // Regex does not implement Hash, so we hash its pattern string.
+                regex.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl ByteStringPattern {
+    /// Creates a new `ByteStringPattern` that matches any byte string.
+    pub fn any() -> Self { ByteStringPattern::Any }
+
+    /// Creates a new `ByteStringPattern` that matches a specific byte string.
+    pub fn exact(value: impl AsRef<[u8]>) -> Self {
+        ByteStringPattern::Exact(value.as_ref().to_vec())
+    }
+
+    /// Creates a new `ByteStringPattern` that matches the binary regex for a
+    /// byte string.
+    pub fn binary_regex(regex: regex::bytes::Regex) -> Self {
+        ByteStringPattern::BinaryRegex(regex)
+    }
+}
+
+impl Matcher for ByteStringPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if let Some(bytes) = envelope.subject().as_byte_string() {
+            match self {
+                ByteStringPattern::Any => vec![vec![envelope.clone()]],
+                ByteStringPattern::Exact(value) => {
+                    if &bytes == value {
+                        vec![vec![envelope.clone()]]
+                    } else {
+                        vec![]
+                    }
+                }
+                ByteStringPattern::BinaryRegex(regex) => {
+                    if regex.is_match(&bytes) {
+                        vec![vec![envelope.clone()]]
+                    } else {
+                        vec![]
+                    }
+                }
+            }
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for ByteStringPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::ByteString(
+                self.clone(),
+            )),
+            code,
+            literals,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dcbor::prelude::*;
+
+    use super::*;
+    use bc_envelope::Envelope;
+
+    #[test]
+    fn test_byte_string_pattern_any() {
+        let bytes = vec![1, 2, 3, 4];
+        let envelope = Envelope::new(CBOR::to_byte_string(bytes));
+        let pattern = ByteStringPattern::any();
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with non-byte-string envelope
+        let text_envelope = Envelope::new("test");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_byte_string_pattern_exact() {
+        let bytes = vec![1, 2, 3, 4];
+        let envelope = Envelope::new(CBOR::to_byte_string(bytes.clone()));
+        let pattern = ByteStringPattern::exact(bytes.clone());
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with different byte string
+        let different_bytes = vec![5, 6, 7, 8];
+        let pattern = ByteStringPattern::exact(different_bytes);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_byte_string_pattern_binary_regex() {
+        let bytes = vec![0x48, 0x65, 0x6c, 0x6c, 0x6f]; // "Hello"
+        let envelope = Envelope::new(CBOR::to_byte_string(bytes.clone()));
+
+        // Test matching regex
+        let regex = regex::bytes::Regex::new(r"^He.*o$").unwrap();
+        let pattern = ByteStringPattern::binary_regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test non-matching regex
+        let regex = regex::bytes::Regex::new(r"^World").unwrap();
+        let pattern = ByteStringPattern::binary_regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test with non-byte-string envelope
+        let text_envelope = Envelope::new("test");
+        let regex = regex::bytes::Regex::new(r".*").unwrap();
+        let pattern = ByteStringPattern::binary_regex(regex);
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/cbor_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/cbor_pattern.rs
@@ -1,0 +1,87 @@
+use dcbor::prelude::*;
+
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path, compile_as_atomic, leaf::LeafPattern,
+        vm::Instr,
+    },
+};
+
+/// Pattern for matching specific CBOR values.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum CBORPattern {
+    /// Matches any CBOR value.
+    Any,
+    /// Matches the specific CBOR value.
+    Exact(CBOR),
+}
+
+impl CBORPattern {
+    /// Creates a new `CborPattern` that matches any CBOR value.
+    pub fn any() -> Self { CBORPattern::Any }
+
+    /// Creates a new `CborPattern` that matches a specific CBOR value.
+    pub fn exact(cbor: CBOR) -> Self { CBORPattern::Exact(cbor) }
+}
+
+impl Matcher for CBORPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        let subject = envelope.subject();
+        let subject_cbor = match subject.as_leaf() {
+            Some(cbor) => cbor,
+            None => return vec![],
+        };
+        match self {
+            CBORPattern::Any => vec![vec![envelope.clone()]],
+            CBORPattern::Exact(expected_cbor) => {
+                if subject_cbor == *expected_cbor {
+                    vec![vec![envelope.clone()]]
+                } else {
+                    vec![]
+                }
+            }
+        }
+    }
+}
+
+impl Compilable for CBORPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Cbor(self.clone())),
+            code,
+            literals,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bc_envelope::Envelope;
+
+    #[test]
+    fn test_cbor_pattern_any() {
+        let envelope = Envelope::new("test");
+        let pattern = CBORPattern::any();
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+    }
+
+    #[test]
+    fn test_cbor_pattern_exact() {
+        let value = "test_value";
+        let envelope = Envelope::new(value);
+        let cbor = envelope.subject().as_leaf().unwrap().clone();
+        let pattern = CBORPattern::exact(cbor);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with different value
+        let different_envelope = Envelope::new("different");
+        let paths = pattern.paths(&different_envelope);
+        assert!(paths.is_empty());
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/date_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/date_pattern.rs
@@ -1,0 +1,340 @@
+use std::ops::RangeInclusive;
+
+use dcbor::{Date, prelude::*};
+
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path, compile_as_atomic, leaf::LeafPattern,
+        vm::Instr,
+    },
+};
+
+/// Pattern for matching dates.
+#[derive(Debug, Clone)]
+pub enum DatePattern {
+    /// Matches any date.
+    Any,
+    /// Matches a specific date.
+    Date(Date),
+    /// Matches dates within a range (inclusive).
+    Range(RangeInclusive<Date>),
+    /// Matches dates that are on or after the specified date.
+    Earliest(Date),
+    /// Matches dates that are on or before the specified date.
+    Latest(Date),
+    /// Matches a date by its ISO-8601 string representation.
+    Iso8601(String),
+    /// Matches dates whose ISO-8601 string representation matches the given
+    /// regex pattern.
+    Regex(regex::Regex),
+}
+
+impl PartialEq for DatePattern {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (DatePattern::Any, DatePattern::Any) => true,
+            (DatePattern::Date(a), DatePattern::Date(b)) => a == b,
+            (DatePattern::Range(a), DatePattern::Range(b)) => a == b,
+            (DatePattern::Earliest(a), DatePattern::Earliest(b)) => a == b,
+            (DatePattern::Latest(a), DatePattern::Latest(b)) => a == b,
+            (DatePattern::Iso8601(a), DatePattern::Iso8601(b)) => a == b,
+            (DatePattern::Regex(a), DatePattern::Regex(b)) => {
+                a.as_str() == b.as_str()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for DatePattern {}
+
+impl std::hash::Hash for DatePattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            DatePattern::Any => {
+                0u8.hash(state);
+            }
+            DatePattern::Date(date) => {
+                1u8.hash(state);
+                date.hash(state);
+            }
+            DatePattern::Range(range) => {
+                2u8.hash(state);
+                range.start().hash(state);
+                range.end().hash(state);
+            }
+            DatePattern::Earliest(date) => {
+                3u8.hash(state);
+                date.hash(state);
+            }
+            DatePattern::Latest(date) => {
+                4u8.hash(state);
+                date.hash(state);
+            }
+            DatePattern::Iso8601(iso_string) => {
+                5u8.hash(state);
+                iso_string.hash(state);
+            }
+            DatePattern::Regex(regex) => {
+                6u8.hash(state);
+                // Regex does not implement Hash, so we hash its pattern string.
+                regex.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl DatePattern {
+    /// Creates a new `DatePattern` that matches any date.
+    pub fn any() -> Self { DatePattern::Any }
+
+    /// Creates a new `DatePattern` that matches a specific date.
+    pub fn date(date: Date) -> Self { DatePattern::Date(date) }
+
+    /// Creates a new `DatePattern` that matches dates within a range
+    /// (inclusive).
+    pub fn range(range: RangeInclusive<Date>) -> Self {
+        DatePattern::Range(range)
+    }
+
+    /// Creates a new `DatePattern` that matches dates that are on or after the
+    /// specified date.
+    pub fn earliest(date: Date) -> Self { DatePattern::Earliest(date) }
+
+    /// Creates a new `DatePattern` that matches dates that are on or before the
+    /// specified date.
+    pub fn latest(date: Date) -> Self { DatePattern::Latest(date) }
+
+    /// Creates a new `DatePattern` that matches a date by its ISO-8601 string
+    /// representation.
+    pub fn iso8601(iso_string: impl Into<String>) -> Self {
+        DatePattern::Iso8601(iso_string.into())
+    }
+
+    /// Creates a new `DatePattern` that matches dates whose ISO-8601 string
+    /// representation matches the given regex pattern.
+    pub fn regex(regex: regex::Regex) -> Self { DatePattern::Regex(regex) }
+}
+
+impl Matcher for DatePattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        // Check if the envelope subject contains a date (CBOR tag 1)
+        if let Some(cbor) = envelope.subject().as_leaf() {
+            if let CBORCase::Tagged(tag, _) = cbor.as_case() {
+                // Check if this is a date tag (tag 1)
+                if tag.value() == 1 {
+                    // Try to extract the date
+                    if let Ok(date) = Date::try_from(cbor.clone()) {
+                        match self {
+                            DatePattern::Any => vec![vec![envelope.clone()]],
+                            DatePattern::Date(expected_date) => {
+                                if date == *expected_date {
+                                    vec![vec![envelope.clone()]]
+                                } else {
+                                    vec![]
+                                }
+                            }
+                            DatePattern::Range(range) => {
+                                if range.contains(&date) {
+                                    vec![vec![envelope.clone()]]
+                                } else {
+                                    vec![]
+                                }
+                            }
+                            DatePattern::Earliest(earliest) => {
+                                if date >= *earliest {
+                                    vec![vec![envelope.clone()]]
+                                } else {
+                                    vec![]
+                                }
+                            }
+                            DatePattern::Latest(latest) => {
+                                if date <= *latest {
+                                    vec![vec![envelope.clone()]]
+                                } else {
+                                    vec![]
+                                }
+                            }
+                            DatePattern::Iso8601(expected_string) => {
+                                let date_string = date.to_string();
+                                if date_string == *expected_string {
+                                    vec![vec![envelope.clone()]]
+                                } else {
+                                    vec![]
+                                }
+                            }
+                            DatePattern::Regex(regex) => {
+                                let date_string = date.to_string();
+                                if regex.is_match(&date_string) {
+                                    vec![vec![envelope.clone()]]
+                                } else {
+                                    vec![]
+                                }
+                            }
+                        }
+                    } else {
+                        // Tagged with date tag but couldn't be parsed as date
+                        vec![]
+                    }
+                } else {
+                    // Not a date tag
+                    vec![]
+                }
+            } else {
+                // Not tagged
+                vec![]
+            }
+        } else {
+            // Not a leaf CBOR value
+            vec![]
+        }
+    }
+}
+
+impl Compilable for DatePattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Date(self.clone())),
+            code,
+            literals,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bc_envelope::Envelope;
+
+    #[test]
+    fn test_date_pattern_any() {
+        // Create a date envelope
+        let date = Date::from_ymd(2023, 12, 25);
+        let envelope = Envelope::new(date.clone());
+
+        let pattern = DatePattern::any();
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with non-date envelope
+        let text_envelope = Envelope::new("test");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_date_pattern_specific() {
+        // Create a date envelope
+        let date = Date::from_ymd(2023, 12, 25);
+        let envelope = Envelope::new(date.clone());
+
+        // Test matching date
+        let pattern = DatePattern::date(date.clone());
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test non-matching date
+        let different_date = Date::from_ymd(2023, 12, 24);
+        let pattern = DatePattern::date(different_date);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_date_pattern_range() {
+        let date = Date::from_ymd(2023, 12, 25);
+        let envelope = Envelope::new(date.clone());
+
+        // Test date within range
+        let start = Date::from_ymd(2023, 12, 20);
+        let end = Date::from_ymd(2023, 12, 30);
+        let pattern = DatePattern::range(start..=end);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test date outside range
+        let start = Date::from_ymd(2023, 12, 26);
+        let end = Date::from_ymd(2023, 12, 30);
+        let pattern = DatePattern::range(start..=end);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test range boundaries (inclusive)
+        let start = Date::from_ymd(2023, 12, 25);
+        let end = Date::from_ymd(2023, 12, 25);
+        let pattern = DatePattern::range(start..=end);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+    }
+
+    #[test]
+    fn test_date_pattern_iso8601() {
+        // Test date-only string (midnight)
+        let date = Date::from_ymd(2023, 12, 25);
+        let envelope = Envelope::new(date.clone());
+
+        let pattern = DatePattern::iso8601("2023-12-25");
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test non-matching string
+        let pattern = DatePattern::iso8601("2023-12-24");
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test date with time
+        let date_with_time = Date::from_ymd_hms(2023, 12, 25, 15, 30, 45);
+        let envelope_with_time = Envelope::new(date_with_time.clone());
+
+        let pattern = DatePattern::iso8601("2023-12-25T15:30:45Z");
+        let paths = pattern.paths(&envelope_with_time);
+        assert_eq!(paths.len(), 1);
+    }
+
+    #[test]
+    fn test_date_pattern_regex() {
+        let date = Date::from_ymd(2023, 12, 25);
+        let envelope = Envelope::new(date.clone());
+
+        // Test regex that matches year 2023
+        let regex = regex::Regex::new(r"^2023-.*").unwrap();
+        let pattern = DatePattern::regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test regex that matches December
+        let regex = regex::Regex::new(r".*-12-.*").unwrap();
+        let pattern = DatePattern::regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test regex that doesn't match
+        let regex = regex::Regex::new(r"^2024-.*").unwrap();
+        let pattern = DatePattern::regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test regex with date-time
+        let date_with_time = Date::from_ymd_hms(2023, 12, 25, 15, 30, 45);
+        let envelope_with_time = Envelope::new(date_with_time.clone());
+
+        let regex = regex::Regex::new(r".*T15:30:45Z$").unwrap();
+        let pattern = DatePattern::regex(regex);
+        let paths = pattern.paths(&envelope_with_time);
+        assert_eq!(paths.len(), 1);
+    }
+
+    #[test]
+    fn test_date_pattern_with_non_date_tagged_cbor() {
+        // Create a non-date tagged CBOR value (e.g., tag 100)
+        let tagged_cbor = CBOR::to_tagged_value(100, "not a date");
+        let envelope = Envelope::new(tagged_cbor);
+
+        // Should not match any date pattern
+        let pattern = DatePattern::any();
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/known_value_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/known_value_pattern.rs
@@ -1,0 +1,249 @@
+use known_values::{KNOWN_VALUES, KnownValue};
+
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path, compile_as_atomic, leaf::LeafPattern,
+        vm::Instr,
+    },
+};
+
+/// Pattern for matching known values.
+#[derive(Debug, Clone)]
+pub enum KnownValuePattern {
+    /// Matches any known value.
+    Any,
+    /// Matches the specific known value.
+    KnownValue(KnownValue),
+    /// Matches the name of a known value.
+    Named(String),
+    /// Matches the regex for a known value name.
+    Regex(regex::Regex),
+}
+
+impl PartialEq for KnownValuePattern {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (KnownValuePattern::Any, KnownValuePattern::Any) => true,
+            (
+                KnownValuePattern::KnownValue(a),
+                KnownValuePattern::KnownValue(b),
+            ) => a == b,
+            (KnownValuePattern::Named(a), KnownValuePattern::Named(b)) => {
+                a == b
+            }
+            (KnownValuePattern::Regex(a), KnownValuePattern::Regex(b)) => {
+                a.as_str() == b.as_str()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for KnownValuePattern {}
+
+impl std::hash::Hash for KnownValuePattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            KnownValuePattern::Any => {
+                0u8.hash(state);
+            }
+            KnownValuePattern::KnownValue(s) => {
+                1u8.hash(state);
+                s.hash(state);
+            }
+            KnownValuePattern::Named(name) => {
+                2u8.hash(state);
+                name.hash(state);
+            }
+            KnownValuePattern::Regex(regex) => {
+                3u8.hash(state);
+                // Regex does not implement Hash, so we hash its pattern string.
+                regex.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl KnownValuePattern {
+    /// Creates a new `KnownValuePattern` that matches any known value.
+    pub fn any() -> Self { KnownValuePattern::Any }
+
+    /// Creates a new `KnownValuePattern` that matches a specific known value.
+    pub fn known_value(value: KnownValue) -> Self {
+        KnownValuePattern::KnownValue(value)
+    }
+
+    /// Creates a new `KnownValuePattern` that matches a known value by name.
+    pub fn named(name: impl Into<String>) -> Self {
+        KnownValuePattern::Named(name.into())
+    }
+
+    /// Creates a new `KnownValuePattern` that matches the regex for a known
+    /// value name.
+    pub fn regex(regex: regex::Regex) -> Self {
+        KnownValuePattern::Regex(regex)
+    }
+}
+
+impl Matcher for KnownValuePattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if let Ok(value) = envelope.extract_subject::<KnownValue>() {
+            match self {
+                KnownValuePattern::Any => vec![vec![envelope.clone()]],
+                KnownValuePattern::KnownValue(expected) => {
+                    if value == *expected {
+                        vec![vec![envelope.clone()]]
+                    } else {
+                        vec![]
+                    }
+                }
+                KnownValuePattern::Named(name) => {
+                    // Look up the known value by name in the global registry
+                    let binding = KNOWN_VALUES.get();
+                    if let Some(known_values_store) = binding.as_ref() {
+                        if let Some(expected_value) =
+                            known_values_store.known_value_named(name)
+                        {
+                            if value == *expected_value {
+                                vec![vec![envelope.clone()]]
+                            } else {
+                                vec![]
+                            }
+                        } else {
+                            // Name not found in registry, no match
+                            vec![]
+                        }
+                    } else {
+                        // Registry not initialized, no match
+                        vec![]
+                    }
+                }
+                KnownValuePattern::Regex(regex) => {
+                    // Check if the known value's name matches the regex
+                    if regex.is_match(&value.name()) {
+                        vec![vec![envelope.clone()]]
+                    } else {
+                        vec![]
+                    }
+                }
+            }
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for KnownValuePattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::KnownValue(self.clone())),
+            code,
+            literals,
+        );
+    }
+}
+
+mod tests {
+
+    #[test]
+    fn test_known_value_pattern_any() {
+        use known_values::KnownValue;
+
+        use crate::{Envelope, Matcher, pattern::leaf::KnownValuePattern};
+
+        let value = KnownValue::new(1);
+        let envelope = Envelope::new(value.clone());
+        let pattern = KnownValuePattern::any();
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with non-known-value envelope
+        let text_envelope = Envelope::new("test");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_known_value_pattern_specific() {
+        use crate::{Envelope, Matcher, pattern::leaf::KnownValuePattern};
+
+        let value = known_values::DATE;
+        let envelope = Envelope::new(value.clone());
+        let pattern = KnownValuePattern::known_value(value.clone());
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with different known value
+        let different_value = known_values::LANGUAGE;
+        let pattern = KnownValuePattern::known_value(different_value);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_known_value_pattern_named() {
+        use crate::{Envelope, Matcher, pattern::leaf::KnownValuePattern};
+
+        let value = known_values::DATE;
+        let envelope = Envelope::new(value.clone());
+
+        // Test matching by name
+        let pattern = KnownValuePattern::named("date");
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with non-matching name
+        let pattern = KnownValuePattern::named("language");
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test with unknown name
+        let pattern = KnownValuePattern::named("unknown_name");
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test with non-known-value envelope
+        let text_envelope = Envelope::new("test");
+        let pattern = KnownValuePattern::named("date");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_known_value_pattern_regex() {
+        use crate::{Envelope, Matcher, pattern::leaf::KnownValuePattern};
+
+        // Test regex that matches "date"
+        let value = known_values::DATE;
+        let envelope = Envelope::new(value.clone());
+        let regex = regex::Regex::new(r"^da.*").unwrap();
+        let pattern = KnownValuePattern::regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test regex that matches names ending with "te"
+        let regex = regex::Regex::new(r".*te$").unwrap();
+        let pattern = KnownValuePattern::regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test regex that doesn't match
+        let regex = regex::Regex::new(r"^lang.*").unwrap();
+        let pattern = KnownValuePattern::regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test with non-known-value envelope
+        let text_envelope = Envelope::new("test");
+        let regex = regex::Regex::new(r".*").unwrap();
+        let pattern = KnownValuePattern::regex(regex);
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/leaf_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/leaf_pattern.rs
@@ -1,0 +1,143 @@
+use super::KnownValuePattern;
+use super::{
+    ArrayPattern, BoolPattern, ByteStringPattern, CBORPattern, DatePattern,
+    MapPattern, NullPattern, NumberPattern, TaggedPattern, TextPattern,
+};
+use crate::{
+    Envelope, Pattern,
+    pattern::{Compilable, Matcher, Path, compile_as_atomic, vm::Instr},
+};
+
+/// Pattern for matching leaf values.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum LeafPattern {
+    /// Matches any leaf.
+    Any,
+    /// Matches the specific CBOR.
+    Cbor(CBORPattern),
+    /// Matches a numeric value.
+    Number(NumberPattern),
+    /// Matches a text value.
+    Text(TextPattern),
+    /// Matches a byte string value.
+    ByteString(ByteStringPattern),
+    /// Matches a tag value.
+    Tag(TaggedPattern),
+    /// Matches an array.
+    Array(ArrayPattern),
+    /// Matches a map.
+    Map(MapPattern),
+    /// Matches a boolean value.
+    Bool(BoolPattern),
+    /// Matches the null value.
+    Null(NullPattern),
+    /// Matches a date value.
+    Date(DatePattern),
+    /// Matches a known value.
+    KnownValue(KnownValuePattern),
+}
+
+impl LeafPattern {
+    /// Creates a new `LeafPattern` that matches any leaf.
+    pub fn any() -> Self { LeafPattern::Any }
+
+    pub fn cbor(pattern: CBORPattern) -> Self { LeafPattern::Cbor(pattern) }
+
+    pub fn number(pattern: NumberPattern) -> Self {
+        LeafPattern::Number(pattern)
+    }
+
+    pub fn text(pattern: TextPattern) -> Self { LeafPattern::Text(pattern) }
+
+    pub fn byte_string(pattern: ByteStringPattern) -> Self {
+        LeafPattern::ByteString(pattern)
+    }
+
+    pub fn tag(pattern: TaggedPattern) -> Self { LeafPattern::Tag(pattern) }
+
+    pub fn array(pattern: ArrayPattern) -> Self { LeafPattern::Array(pattern) }
+
+    pub fn map(pattern: MapPattern) -> Self { LeafPattern::Map(pattern) }
+
+    pub fn boolean(pattern: BoolPattern) -> Self { LeafPattern::Bool(pattern) }
+
+    pub fn null(pattern: NullPattern) -> Self { LeafPattern::Null(pattern) }
+
+    pub fn date(pattern: DatePattern) -> Self { LeafPattern::Date(pattern) }
+
+    pub fn known_value(pattern: KnownValuePattern) -> Self {
+        LeafPattern::KnownValue(pattern)
+    }
+}
+
+impl Matcher for LeafPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        match self {
+            LeafPattern::Any => {
+                if envelope.is_leaf() {
+                    vec![vec![envelope.clone()]]
+                } else {
+                    vec![]
+                }
+            }
+            LeafPattern::Cbor(pattern) => pattern.paths(envelope),
+            LeafPattern::Number(pattern) => pattern.paths(envelope),
+            LeafPattern::Text(pattern) => pattern.paths(envelope),
+            LeafPattern::ByteString(pattern) => pattern.paths(envelope),
+            LeafPattern::Tag(pattern) => pattern.paths(envelope),
+            LeafPattern::Array(pattern) => pattern.paths(envelope),
+            LeafPattern::Map(pattern) => pattern.paths(envelope),
+            LeafPattern::Bool(pattern) => pattern.paths(envelope),
+            LeafPattern::Null(pattern) => pattern.paths(envelope),
+            LeafPattern::Date(pattern) => pattern.paths(envelope),
+            LeafPattern::KnownValue(pattern) => pattern.paths(envelope),
+        }
+    }
+}
+
+impl Compilable for LeafPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        match self {
+            LeafPattern::Any => {
+                compile_as_atomic(
+                    &Pattern::Leaf(LeafPattern::Any),
+                    code,
+                    literals,
+                );
+            }
+            LeafPattern::Cbor(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::Number(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::Text(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::ByteString(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::Tag(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::Array(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::Map(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::Bool(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::Null(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::Date(pattern) => {
+                pattern.compile(code, literals);
+            }
+            LeafPattern::KnownValue(pattern) => {
+                pattern.compile(code, literals);
+            }
+        }
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/map_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/map_pattern.rs
@@ -1,0 +1,113 @@
+use std::ops::RangeInclusive;
+
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path, compile_as_atomic, leaf::LeafPattern,
+        vm::Instr,
+    },
+};
+
+/// Pattern for matching maps.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum MapPattern {
+    /// Matches any map.
+    Any,
+    /// Matches maps with a specific count of entries.
+    Count(RangeInclusive<usize>),
+}
+
+impl MapPattern {
+    /// Creates a new `MapPattern` that matches any map.
+    pub fn any() -> Self { MapPattern::Any }
+
+    /// Creates a new `MapPattern` that matches maps with a specific count of
+    /// entries.
+    pub fn range_count(range: RangeInclusive<usize>) -> Self {
+        MapPattern::Count(range)
+    }
+
+    /// Creates a new `MapPattern` that matches maps with exactly the specified
+    /// count of entries.
+    pub fn count(count: usize) -> Self { MapPattern::Count(count..=count) }
+}
+
+impl Matcher for MapPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if let Some(map) = envelope.subject().as_map() {
+            match self {
+                MapPattern::Any => vec![vec![envelope.clone()]],
+                MapPattern::Count(range) => {
+                    if range.contains(&map.len()) {
+                        vec![vec![envelope.clone()]]
+                    } else {
+                        vec![]
+                    }
+                }
+            }
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for MapPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Map(self.clone())),
+            code,
+            literals,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dcbor::prelude::*;
+
+    use super::*;
+    use bc_envelope::Envelope;
+
+    #[test]
+    fn test_map_pattern_any() {
+        // Create a CBOR map directly
+        let mut cbor_map = Map::new();
+        cbor_map.insert("key1", "value1");
+        cbor_map.insert("key2", "value2");
+        let envelope = Envelope::new(cbor_map);
+
+        let pattern = MapPattern::any();
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with non-map envelope
+        let text_envelope = Envelope::new("test");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_map_pattern_count() {
+        // Create a CBOR map directly
+        let mut cbor_map = Map::new();
+        cbor_map.insert("key1", "value1");
+        cbor_map.insert("key2", "value2");
+        let envelope = Envelope::new(cbor_map);
+
+        // Test exact count
+        let pattern = MapPattern::count(2);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test count range
+        let pattern = MapPattern::range_count(1..=3);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test count mismatch
+        let pattern = MapPattern::count(5);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/mod.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/mod.rs
@@ -1,0 +1,27 @@
+// Leaf patterns - patterns dealing with CBOR leaf node values
+
+mod array_pattern;
+mod bool_pattern;
+mod byte_string_pattern;
+mod cbor_pattern;
+mod date_pattern;
+mod known_value_pattern;
+mod leaf_pattern;
+mod map_pattern;
+mod null_pattern;
+mod number_pattern;
+mod tagged_pattern;
+mod text_pattern;
+
+pub(crate) use array_pattern::ArrayPattern;
+pub(crate) use bool_pattern::BoolPattern;
+pub(crate) use byte_string_pattern::ByteStringPattern;
+pub(crate) use cbor_pattern::CBORPattern;
+pub(crate) use date_pattern::DatePattern;
+pub(crate) use known_value_pattern::KnownValuePattern;
+pub(crate) use leaf_pattern::LeafPattern;
+pub(crate) use map_pattern::MapPattern;
+pub(crate) use null_pattern::NullPattern;
+pub(crate) use number_pattern::NumberPattern;
+pub(crate) use tagged_pattern::TaggedPattern;
+pub(crate) use text_pattern::TextPattern;

--- a/bc-envelope-pattern/src/pattern/leaf/null_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/null_pattern.rs
@@ -1,0 +1,63 @@
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path, compile_as_atomic, leaf::LeafPattern,
+        vm::Instr,
+    },
+};
+
+/// Pattern for matching null values.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum NullPattern {
+    /// Matches any null value.
+    Any,
+}
+
+impl NullPattern {
+    /// Creates a new `NullPattern` that matches any null value.
+    pub fn any() -> Self { NullPattern::Any }
+}
+
+impl Matcher for NullPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        match self {
+            NullPattern::Any => {
+                if envelope.subject().is_null() {
+                    vec![vec![envelope.clone()]]
+                } else {
+                    vec![]
+                }
+            }
+        }
+    }
+}
+
+impl Compilable for NullPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Null(self.clone())),
+            code,
+            literals,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bc_envelope::Envelope;
+
+    #[test]
+    fn test_null_pattern_any() {
+        let null_envelope = Envelope::null();
+        let pattern = NullPattern::any();
+        let paths = pattern.paths(&null_envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![null_envelope.clone()]);
+
+        // Test with non-null envelope
+        let text_envelope = Envelope::new("test");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/number_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/number_pattern.rs
@@ -1,0 +1,201 @@
+use std::ops::RangeInclusive;
+
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path, compile_as_atomic, leaf::LeafPattern,
+        vm::Instr,
+    },
+};
+
+/// Pattern for matching number values.
+#[derive(Debug, Clone)]
+pub enum NumberPattern {
+    /// Matches any number.
+    Any,
+    /// Matches the specific number.
+    Exact(f64),
+    /// Matches numbers within a range, inclusive (..=).
+    Range(RangeInclusive<f64>),
+    /// Matches numbers that are greater than the specified value.
+    GreaterThan(f64),
+    /// Matches numbers that are greater than or equal to the specified value.
+    GreaterThanOrEqual(f64),
+    /// Matches numbers that are less than the specified value.
+    LessThan(f64),
+    /// Matches numbers that are less than or equal to the specified value.
+    LessThanOrEqual(f64),
+    /// Matches numbers that are NaN (Not a Number).
+    NaN,
+}
+
+impl std::hash::Hash for NumberPattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            NumberPattern::Any => 0u8.hash(state),
+            NumberPattern::Exact(value) => {
+                1u8.hash(state);
+                value.to_bits().hash(state);
+            }
+            NumberPattern::Range(range) => {
+                2u8.hash(state);
+                range.start().to_bits().hash(state);
+                range.end().to_bits().hash(state);
+            }
+            NumberPattern::GreaterThan(value) => {
+                3u8.hash(state);
+                value.to_bits().hash(state);
+            }
+            NumberPattern::GreaterThanOrEqual(value) => {
+                4u8.hash(state);
+                value.to_bits().hash(state);
+            }
+            NumberPattern::LessThan(value) => {
+                5u8.hash(state);
+                value.to_bits().hash(state);
+            }
+            NumberPattern::LessThanOrEqual(value) => {
+                6u8.hash(state);
+                value.to_bits().hash(state);
+            }
+            NumberPattern::NaN => 7u8.hash(state),
+        }
+    }
+}
+
+impl PartialEq for NumberPattern {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (NumberPattern::Any, NumberPattern::Any) => true,
+            (NumberPattern::Exact(a), NumberPattern::Exact(b)) => a == b,
+            (NumberPattern::Range(a), NumberPattern::Range(b)) => a == b,
+            (NumberPattern::GreaterThan(a), NumberPattern::GreaterThan(b)) => {
+                a == b
+            }
+            (
+                NumberPattern::GreaterThanOrEqual(a),
+                NumberPattern::GreaterThanOrEqual(b),
+            ) => a == b,
+            (NumberPattern::LessThan(a), NumberPattern::LessThan(b)) => a == b,
+            (
+                NumberPattern::LessThanOrEqual(a),
+                NumberPattern::LessThanOrEqual(b),
+            ) => a == b,
+            (NumberPattern::NaN, NumberPattern::NaN) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for NumberPattern {}
+
+impl NumberPattern {
+    /// Creates a new `NumberPattern` that matches any number.
+    pub fn any() -> Self { NumberPattern::Any }
+
+    /// Creates a new `NumberPattern` that matches the exact number.
+    pub fn exact<T>(value: T) -> Self
+    where
+        T: Into<f64>,
+    {
+        NumberPattern::Exact(value.into())
+    }
+
+    /// Creates a new `NumberPattern` that matches numbers within the specified
+    /// range.
+    pub fn range<A>(range: RangeInclusive<A>) -> Self
+    where
+        A: Into<f64> + Copy,
+    {
+        let start = (*range.start()).into();
+        let end = (*range.end()).into();
+        NumberPattern::Range(RangeInclusive::new(start, end))
+    }
+
+    /// Creates a new `NumberPattern` that matches numbers greater than the
+    /// specified value.
+    pub fn greater_than<T>(value: T) -> Self
+    where
+        T: Into<f64>,
+    {
+        NumberPattern::GreaterThan(value.into())
+    }
+
+    /// Creates a new `NumberPattern` that matches numbers greater than or
+    /// equal to the specified value.
+    pub fn greater_than_or_equal<T>(value: T) -> Self
+    where
+        T: Into<f64>,
+    {
+        NumberPattern::GreaterThanOrEqual(value.into())
+    }
+
+    /// Creates a new `NumberPattern` that matches numbers less than the
+    /// specified value.
+    pub fn less_than<T>(value: T) -> Self
+    where
+        T: Into<f64>,
+    {
+        NumberPattern::LessThan(value.into())
+    }
+
+    /// Creates a new `NumberPattern` that matches numbers less than or equal
+    /// to the specified value.
+    pub fn less_than_or_equal<T>(value: T) -> Self
+    where
+        T: Into<f64>,
+    {
+        NumberPattern::LessThanOrEqual(value.into())
+    }
+
+    /// Creates a new `NumberPattern` that matches NaN values.
+    pub fn nan() -> Self { NumberPattern::NaN }
+}
+
+impl Matcher for NumberPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        let subject = envelope.subject();
+        let is_hit = match self {
+            NumberPattern::Any => subject.is_number(),
+            NumberPattern::Exact(want) => {
+                subject.extract_subject().ok() == Some(*want)
+            }
+            NumberPattern::Range(want) => {
+                subject.extract_subject().is_ok_and(|n| want.contains(&n))
+            }
+            NumberPattern::GreaterThan(want) => {
+                subject.extract_subject().is_ok_and(|n: f64| n > *want)
+            }
+            NumberPattern::GreaterThanOrEqual(want) => {
+                subject.extract_subject().is_ok_and(|n: f64| n >= *want)
+            }
+            NumberPattern::LessThan(want) => {
+                subject.extract_subject().is_ok_and(|n: f64| n < *want)
+            }
+            NumberPattern::LessThanOrEqual(want) => {
+                subject.extract_subject().is_ok_and(|n: f64| n <= *want)
+            }
+            NumberPattern::NaN => subject.is_nan(),
+        };
+
+        if is_hit {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for NumberPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        // A NumberPattern is a *leaf* predicate; it never changes
+        // the current envelope pointer, so the default atomic helper
+        // is perfect.  We must wrap `self` back into the outer
+        // `Pattern::Leaf` variant so it can be stored in `literals`.
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Number(self.clone())),
+            code,
+            literals,
+        );
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/tagged_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/tagged_pattern.rs
@@ -1,0 +1,267 @@
+use dcbor::prelude::*;
+use bc_envelope::prelude::with_tags;
+
+use crate::{
+    pattern::{compile_as_atomic, leaf::LeafPattern, vm::Instr, Compilable, Matcher, Path}, Envelope, Pattern
+};
+
+/// Pattern for matching tag values.
+#[derive(Debug, Clone)]
+pub enum TaggedPattern {
+    /// Matches any tagged leaf.
+    Any,
+    /// Matches any leaf with the specific tag.
+    Tag(Tag),
+    /// Matches a leaf with a tag having the given name in the global tags
+    /// registry.
+    Named(String),
+    /// Matches a leaf with a tag whose name matches the given regex pattern.
+    Regex(regex::Regex),
+}
+
+impl PartialEq for TaggedPattern {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (TaggedPattern::Any, TaggedPattern::Any) => true,
+            (TaggedPattern::Tag(a), TaggedPattern::Tag(b)) => a == b,
+            (TaggedPattern::Named(a), TaggedPattern::Named(b)) => a == b,
+            (TaggedPattern::Regex(a), TaggedPattern::Regex(b)) => {
+                a.as_str() == b.as_str()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for TaggedPattern {}
+
+impl std::hash::Hash for TaggedPattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            TaggedPattern::Any => {
+                0u8.hash(state);
+            }
+            TaggedPattern::Tag(tag) => {
+                1u8.hash(state);
+                tag.hash(state);
+            }
+            TaggedPattern::Named(name) => {
+                2u8.hash(state);
+                name.hash(state);
+            }
+            TaggedPattern::Regex(regex) => {
+                3u8.hash(state);
+                // Regex does not implement Hash, so we hash its pattern string.
+                regex.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl TaggedPattern {
+    /// Creates a new `TaggedPattern` that matches any tag.
+    pub fn any() -> Self { TaggedPattern::Any }
+
+    /// Creates a new `TaggedPattern` that matches a specific tag.
+    pub fn with_tag(tag: Tag) -> Self { TaggedPattern::Tag(tag) }
+
+    /// Creates a new `TaggedPattern` that matches a specific tag value.
+    pub fn with_tag_value(value: u64) -> Self {
+        TaggedPattern::Tag(Tag::with_value(value))
+    }
+
+    /// Creates a new `TaggedPattern` that matches a tag by its name in the
+    /// global tags registry.
+    pub fn with_tag_name(name: impl Into<String>) -> Self {
+        TaggedPattern::Named(name.into())
+    }
+
+    /// Creates a new `TaggedPattern` that matches tags whose names match the
+    /// given regex pattern.
+    pub fn with_tag_regex(regex: regex::Regex) -> Self {
+        TaggedPattern::Regex(regex)
+    }
+}
+
+impl Matcher for TaggedPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        // Check if the envelope subject contains a tagged value
+        if let Some(cbor) = envelope.subject().as_leaf() {
+            if let CBORCase::Tagged(tag, _) = cbor.as_case() {
+                match self {
+                    TaggedPattern::Any => vec![vec![envelope.clone()]],
+                    TaggedPattern::Tag(expected_tag) => {
+                        if expected_tag.value() == tag.value() {
+                            vec![vec![envelope.clone()]]
+                        } else {
+                            vec![]
+                        }
+                    }
+                    TaggedPattern::Named(name) => {
+                        // Look up the tag by name in the global tags registry
+                        with_tags!(|tags: &TagsStore| {
+                            if let Some(expected_tag) = tags.tag_for_name(name)
+                            {
+                                if expected_tag.value() == tag.value() {
+                                    vec![vec![envelope.clone()]]
+                                } else {
+                                    vec![]
+                                }
+                            } else {
+                                // Name not found in registry, no match
+                                vec![]
+                            }
+                        })
+                    }
+                    TaggedPattern::Regex(regex) => {
+                        // Check if the tag's name (from registry) matches the
+                        // regex
+                        with_tags!(|tags: &TagsStore| {
+                            if let Some(tag_name) =
+                                tags.assigned_name_for_tag(tag)
+                            {
+                                if regex.is_match(&tag_name) {
+                                    vec![vec![envelope.clone()]]
+                                } else {
+                                    vec![]
+                                }
+                            } else {
+                                // Tag has no name in registry, no match
+                                vec![]
+                            }
+                        })
+                    }
+                }
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for TaggedPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Tag(self.clone())),
+            code,
+            literals,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bc_envelope::Envelope;
+
+    #[test]
+    fn test_tag_pattern_any() {
+        // Create a tagged envelope
+        let tagged_cbor = CBOR::to_tagged_value(100, "tagged_value");
+        let envelope = Envelope::new(tagged_cbor);
+
+        let pattern = TaggedPattern::any();
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with non-tagged envelope
+        let text_envelope = Envelope::new("test");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_tag_pattern_tag() {
+        // Create a tagged envelope
+        let tagged_cbor = CBOR::to_tagged_value(100, "tagged_value");
+        let envelope = Envelope::new(tagged_cbor);
+
+        // Test matching tag
+        let pattern = TaggedPattern::with_tag_value(100);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+
+        // Test non-matching tag
+        let pattern = TaggedPattern::with_tag_value(200);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_tag_pattern_named() {
+        // Ensure tags are registered for testing
+        dcbor::register_tags();
+        bc_components::register_tags();
+
+        // Create a tagged envelope using a registered tag (e.g., date tag = 1)
+        let tagged_cbor = CBOR::to_tagged_value(1, "2023-12-25");
+        let envelope = Envelope::new(tagged_cbor);
+
+        // Test matching by name (dcbor registers tag 1 as "date")
+        let pattern = TaggedPattern::with_tag_name("date");
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test with non-matching name
+        let pattern = TaggedPattern::with_tag_name("unknown_tag");
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test with non-tagged envelope
+        let text_envelope = Envelope::new("test");
+        let pattern = TaggedPattern::with_tag_name("date");
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_tag_pattern_regex() {
+        // Ensure tags are registered for testing
+        dcbor::register_tags();
+        bc_components::register_tags();
+
+        // Create a tagged envelope using a registered tag (e.g., date tag = 1)
+        let tagged_cbor = CBOR::to_tagged_value(1, "2023-12-25");
+        let envelope = Envelope::new(tagged_cbor);
+
+        // Test regex that matches "date"
+        let regex = regex::Regex::new(r"^da.*").unwrap();
+        let pattern = TaggedPattern::with_tag_regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test regex that matches names ending with "te"
+        let regex = regex::Regex::new(r".*te$").unwrap();
+        let pattern = TaggedPattern::with_tag_regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], vec![envelope.clone()]);
+
+        // Test regex that doesn't match
+        let regex = regex::Regex::new(r"^unknown.*").unwrap();
+        let pattern = TaggedPattern::with_tag_regex(regex);
+        let paths = pattern.paths(&envelope);
+        assert!(paths.is_empty());
+
+        // Test with non-tagged envelope
+        let text_envelope = Envelope::new("test");
+        let regex = regex::Regex::new(r".*").unwrap();
+        let pattern = TaggedPattern::with_tag_regex(regex);
+        let paths = pattern.paths(&text_envelope);
+        assert!(paths.is_empty());
+
+        // Test with unregistered tag (should not match any regex)
+        let unregistered_tagged_cbor =
+            CBOR::to_tagged_value(999, "unregistered_value");
+        let unregistered_envelope = Envelope::new(unregistered_tagged_cbor);
+        let regex = regex::Regex::new(r".*").unwrap(); // Match everything
+        let pattern = TaggedPattern::with_tag_regex(regex);
+        let paths = pattern.paths(&unregistered_envelope);
+        assert!(paths.is_empty()); // Should be empty because tag 999 has no name in registry
+    }
+}

--- a/bc-envelope-pattern/src/pattern/leaf/text_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/leaf/text_pattern.rs
@@ -1,0 +1,91 @@
+use crate::{
+    pattern::{compile_as_atomic, leaf::LeafPattern, vm::Instr, Compilable, Matcher, Path}, Envelope, Pattern
+};
+
+/// Pattern for matching text values.
+#[derive(Debug, Clone)]
+pub enum TextPattern {
+    /// Matches any text.
+    Any,
+    /// Matches the specific text.
+    Exact(String),
+    /// Matches the regex for a text.
+    Regex(regex::Regex),
+}
+
+impl PartialEq for TextPattern {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (TextPattern::Any, TextPattern::Any) => true,
+            (TextPattern::Exact(a), TextPattern::Exact(b)) => a == b,
+            (TextPattern::Regex(a), TextPattern::Regex(b)) => {
+                a.as_str() == b.as_str()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for TextPattern {}
+
+impl std::hash::Hash for TextPattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            TextPattern::Any => {
+                0u8.hash(state);
+            }
+            TextPattern::Exact(s) => {
+                1u8.hash(state);
+                s.hash(state);
+            }
+            TextPattern::Regex(regex) => {
+                2u8.hash(state);
+                // Regex does not implement Hash, so we hash its pattern string.
+                regex.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl TextPattern {
+    /// Creates a new `TextPattern` that matches any text.
+    pub fn any() -> Self { TextPattern::Any }
+
+    /// Creates a new `TextPattern` that matches the specific text.
+    pub fn exact<T: Into<String>>(value: T) -> Self {
+        TextPattern::Exact(value.into())
+    }
+
+    /// Creates a new `TextPattern` that matches the regex for a text.
+    pub fn regex(regex: regex::Regex) -> Self { TextPattern::Regex(regex) }
+}
+
+impl Matcher for TextPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        let is_hit =
+            envelope
+                .extract_subject::<String>()
+                .ok()
+                .is_some_and(|value| match self {
+                    TextPattern::Any => true,
+                    TextPattern::Exact(want) => value == *want,
+                    TextPattern::Regex(regex) => regex.is_match(&value),
+                });
+
+        if is_hit {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for TextPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Leaf(LeafPattern::Text(self.clone())),
+            code,
+            literals,
+        );
+    }
+}

--- a/bc-envelope-pattern/src/pattern/matcher.rs
+++ b/bc-envelope-pattern/src/pattern/matcher.rs
@@ -1,0 +1,11 @@
+use bc_envelope::Envelope;
+
+pub type Path = Vec<Envelope>;
+
+pub trait Matcher: std::fmt::Debug + Clone {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path>;
+
+    fn matches(&self, envelope: &Envelope) -> bool {
+        !self.paths(envelope).is_empty()
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/and_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/and_pattern.rs
@@ -1,0 +1,39 @@
+use crate::{
+    Envelope,
+    pattern::{Compilable, Matcher, Path, Pattern, vm::Instr},
+};
+
+/// A pattern that matches if all contained patterns match.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct AndPattern {
+    pub patterns: Vec<Pattern>,
+}
+
+impl AndPattern {
+    /// Creates a new `AndPattern` with the given patterns.
+    pub fn new(patterns: Vec<Pattern>) -> Self { AndPattern { patterns } }
+}
+
+impl Matcher for AndPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if self
+            .patterns
+            .iter()
+            .all(|pattern| pattern.matches(envelope))
+        {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for AndPattern {
+    /// Compile into byte-code (AND = all must match).
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        // Each pattern must match at this position
+        for pattern in &self.patterns {
+            pattern.compile(code, lits);
+        }
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/any_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/any_pattern.rs
@@ -1,0 +1,37 @@
+use crate::{
+    pattern::{compile_as_atomic, meta::MetaPattern, vm::Instr, Compilable, Matcher, Path, Pattern}, Envelope
+};
+
+/// A pattern that matches if any contained pattern matches.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct AnyPattern;
+
+impl AnyPattern {
+    /// Creates a new `AnyPattern`.
+    pub fn new() -> Self {
+        AnyPattern
+    }
+}
+
+impl Default for AnyPattern {
+    fn default() -> Self {
+        AnyPattern
+    }
+}
+
+impl Matcher for AnyPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        // Always return a path containing the envelope itself.
+        vec![vec![envelope.clone()]]
+    }
+}
+
+impl Compilable for AnyPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Meta(MetaPattern::Any(self.clone())),
+            code,
+            literals,
+        );
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/capture_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/capture_pattern.rs
@@ -1,0 +1,27 @@
+//! Simple capture wrapper.  For now we only emit SAVE instructions;
+//! future work can attach names to paths.
+
+use crate::{
+    Envelope, Matcher, Path,
+    pattern::{Compilable, Pattern, vm::Instr},
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct CapturePattern {
+    pub name: String,
+    pub inner: Box<Pattern>,
+}
+
+impl Matcher for CapturePattern {
+    fn paths(&self, _envelope: &Envelope) -> Vec<Path> {
+        todo!();
+    }
+}
+
+impl Compilable for CapturePattern {
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        code.push(Instr::Save); // start
+        self.inner.compile(code, lits);
+        code.push(Instr::Save); // end
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/meta_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/meta_pattern.rs
@@ -1,0 +1,78 @@
+use super::{
+    AndPattern, CapturePattern, NotPattern, OrPattern, RepeatPattern,
+    SearchPattern, SequencePattern,
+};
+use crate::{
+    pattern::{meta::AnyPattern, meta::NonePattern, vm::Instr, Compilable, Matcher, Path}, Envelope, Pattern
+};
+
+/// Pattern for combining and modifying other patterns.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum MetaPattern {
+    /// Always matches.
+    Any(AnyPattern),
+    /// Never matches.
+    None(NonePattern),
+    /// Matches if all contained patterns match.
+    And(AndPattern),
+    /// Matches if any contained pattern matches.
+    Or(OrPattern),
+    /// Matches if the inner pattern does not match.
+    Not(NotPattern),
+    /// Searches the entire envelope tree for matches.
+    Search(SearchPattern),
+    /// Matches a sequence of patterns.
+    Sequence(SequencePattern),
+    /// Matches with repetition.
+    Repeat(RepeatPattern),
+    /// Captures a pattern match.
+    Capture(CapturePattern),
+}
+
+impl MetaPattern {
+    pub fn and(pattern: AndPattern) -> Self { MetaPattern::And(pattern) }
+
+    pub fn or(pattern: OrPattern) -> Self { MetaPattern::Or(pattern) }
+
+    pub fn search(pattern: SearchPattern) -> Self {
+        MetaPattern::Search(pattern)
+    }
+
+    pub fn sequence(pattern: SequencePattern) -> Self {
+        MetaPattern::Sequence(pattern)
+    }
+
+    pub fn not(pattern: NotPattern) -> Self { MetaPattern::Not(pattern) }
+}
+
+impl Matcher for MetaPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        match self {
+            MetaPattern::Any(pattern) => pattern.paths(envelope),
+            MetaPattern::None(pattern) => pattern.paths(envelope),
+            MetaPattern::And(pattern) => pattern.paths(envelope),
+            MetaPattern::Or(pattern) => pattern.paths(envelope),
+            MetaPattern::Not(pattern) => pattern.paths(envelope),
+            MetaPattern::Search(pattern) => pattern.paths(envelope),
+            MetaPattern::Sequence(pattern) => pattern.paths(envelope),
+            MetaPattern::Repeat(pattern) => pattern.paths(envelope),
+            MetaPattern::Capture(pattern) => pattern.paths(envelope),
+        }
+    }
+}
+
+impl Compilable for MetaPattern {
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        match self {
+            MetaPattern::Any(pattern) => pattern.compile(code, lits),
+            MetaPattern::None(pattern) => pattern.compile(code, lits),
+            MetaPattern::And(pattern) => pattern.compile(code, lits),
+            MetaPattern::Or(pattern) => pattern.compile(code, lits),
+            MetaPattern::Not(pattern) => pattern.compile(code, lits),
+            MetaPattern::Search(pattern) => pattern.compile(code, lits),
+            MetaPattern::Sequence(pattern) => pattern.compile(code, lits),
+            MetaPattern::Repeat(pattern) => pattern.compile(code, lits),
+            MetaPattern::Capture(pattern) => pattern.compile(code, lits),
+        }
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/mod.rs
+++ b/bc-envelope-pattern/src/pattern/meta/mod.rs
@@ -1,0 +1,23 @@
+// Meta patterns - patterns for combining and modifying other patterns
+
+mod and_pattern;
+mod any_pattern;
+mod capture_pattern;
+mod meta_pattern;
+mod none_pattern;
+mod not_pattern;
+mod or_pattern;
+mod repeat_pattern;
+mod search_pattern;
+mod sequence_pattern;
+
+pub(crate) use and_pattern::AndPattern;
+pub(crate) use any_pattern::AnyPattern;
+pub(crate) use capture_pattern::CapturePattern;
+pub(crate) use meta_pattern::MetaPattern;
+pub(crate) use none_pattern::NonePattern;
+pub(crate) use not_pattern::NotPattern;
+pub(crate) use or_pattern::OrPattern;
+pub(crate) use repeat_pattern::RepeatPattern;
+pub(crate) use search_pattern::SearchPattern;
+pub(crate) use sequence_pattern::SequencePattern;

--- a/bc-envelope-pattern/src/pattern/meta/none_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/none_pattern.rs
@@ -1,0 +1,37 @@
+use crate::{
+    pattern::{compile_as_atomic, meta::MetaPattern, vm::Instr, Compilable, Matcher, Path, Pattern}, Envelope
+};
+
+/// A pattern that matches if any contained pattern matches.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct NonePattern;
+
+impl NonePattern {
+    /// Creates a new `NonePattern`.
+    pub fn new() -> Self {
+        NonePattern
+    }
+}
+
+impl Default for NonePattern {
+    fn default() -> Self {
+        NonePattern
+    }
+}
+
+impl Matcher for NonePattern {
+    fn paths(&self, _envelope: &Envelope) -> Vec<Path> {
+        // Never matches any element.
+        Vec::new()
+    }
+}
+
+impl Compilable for NonePattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Meta(MetaPattern::None(self.clone())),
+            code,
+            literals,
+        );
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/not_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/not_pattern.rs
@@ -1,0 +1,100 @@
+use crate::{
+    Envelope,
+    pattern::{Compilable, Matcher, Path, Pattern, vm::Instr},
+};
+
+/// A pattern that negates another pattern; matches when the inner pattern does
+/// not match.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct NotPattern {
+    pub pattern: Box<Pattern>,
+}
+
+impl NotPattern {
+    /// Creates a new `NotPattern` with the given pattern.
+    pub fn new(pattern: Pattern) -> Self {
+        NotPattern { pattern: Box::new(pattern) }
+    }
+}
+
+impl Matcher for NotPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        // If the inner pattern doesn't match, then we return the current
+        // envelope as a match
+        if !self.pattern.matches(envelope) {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for NotPattern {
+    /// Compile into byte-code (NOT = negation of the inner pattern).
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        // NOT = check that pattern doesn't match
+        let idx = literals.len();
+        literals.push(self.pattern.as_ref().clone());
+        code.push(Instr::NotMatch { pat_idx: idx });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pattern::Pattern;
+
+    #[test]
+    fn test_not_pattern() {
+        // Create a simple envelope
+        let envelope = Envelope::new("test");
+
+        // Pattern that matches text "test"
+        let text_pattern = Pattern::text("test");
+        assert!(text_pattern.matches(&envelope));
+
+        // Not pattern that negates the text pattern
+        let not_pattern = NotPattern::new(text_pattern);
+        assert!(!not_pattern.matches(&envelope));
+
+        // Using the Pattern::not_matching constructor
+        assert!(
+            !Pattern::not_matching(Pattern::text("test")).matches(&envelope)
+        );
+
+        // Not pattern with a pattern that doesn't match
+        let not_matching_pattern = Pattern::text("different");
+        assert!(!not_matching_pattern.matches(&envelope));
+
+        let double_not = NotPattern::new(not_matching_pattern);
+        assert!(double_not.matches(&envelope));
+
+        // Using the Pattern::not_matching constructor
+        assert!(
+            Pattern::not_matching(Pattern::text("different"))
+                .matches(&envelope)
+        );
+    }
+
+    #[test]
+    fn test_not_pattern_paths() {
+        // Create a simple envelope
+        let envelope = Envelope::new("test");
+
+        // Pattern that doesn't match
+        let not_matching_pattern = Pattern::text("different");
+        let not_pattern = NotPattern::new(not_matching_pattern);
+
+        let paths = not_pattern.paths(&envelope);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].len(), 1);
+        assert_eq!(paths[0][0].extract_subject::<String>().unwrap(), "test");
+
+        // Pattern that does match
+        let matching_pattern = Pattern::text("test");
+        let not_pattern = NotPattern::new(matching_pattern);
+
+        let paths = not_pattern.paths(&envelope);
+        assert_eq!(paths.len(), 0);
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/or_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/or_pattern.rs
@@ -1,0 +1,75 @@
+use crate::{
+    Envelope,
+    pattern::{Compilable, Matcher, Path, Pattern, vm::Instr},
+};
+
+/// A pattern that matches if any contained pattern matches.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct OrPattern {
+    pub patterns: Vec<Pattern>,
+}
+
+impl OrPattern {
+    /// Creates a new `OrPattern` with the given patterns.
+    pub fn new(patterns: Vec<Pattern>) -> Self { OrPattern { patterns } }
+}
+
+impl Matcher for OrPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if self
+            .patterns
+            .iter()
+            .any(|pattern| pattern.matches(envelope))
+        {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for OrPattern {
+    /// Compile into byte-code (OR = any can match).
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        if self.patterns.is_empty() {
+            return;
+        }
+
+        // For N patterns: Split(p1, Split(p2, ... Split(pN-1, pN)))
+        let mut splits = Vec::new();
+
+        // Generate splits for all but the last pattern
+        for _ in 0..self.patterns.len() - 1 {
+            splits.push(code.len());
+            code.push(Instr::Split { a: 0, b: 0 }); // Placeholder
+        }
+
+        // Now fill in the actual split targets
+        for (i, pattern) in self.patterns.iter().enumerate() {
+            let pattern_start = code.len();
+
+            // Compile this pattern
+            pattern.compile(code, lits);
+
+            // This pattern will jump to the end if it matches
+            let jump_past_all = code.len();
+            code.push(Instr::Jump(0)); // Placeholder
+
+            // If there's a next pattern, update the split to point here
+            if i < self.patterns.len() - 1 {
+                let next_pattern = code.len();
+                code[splits[i]] =
+                    Instr::Split { a: pattern_start, b: next_pattern };
+            }
+
+            // Will patch this jump once we know where "past all" is
+            splits.push(jump_past_all);
+        }
+
+        // Now patch all the jumps to point past all the patterns
+        let past_all = code.len();
+        for &jump in &splits[self.patterns.len() - 1..] {
+            code[jump] = Instr::Jump(past_all);
+        }
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/repeat_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/repeat_pattern.rs
@@ -1,0 +1,35 @@
+//! AST node + compiler for `{min,max}` quantifiers.
+
+use crate::{
+    Envelope, Matcher, Path,
+    pattern::{Compilable, Greediness, Pattern, vm::Instr},
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct RepeatPattern {
+    pub sub: Box<Pattern>,
+    pub min: usize,
+    pub max: Option<usize>, // None == unbounded
+    pub mode: Greediness,
+}
+
+impl Matcher for RepeatPattern {
+    fn paths(&self, _envelope: &Envelope) -> Vec<Path> {
+        todo!();
+    }
+}
+
+
+impl Compilable for RepeatPattern {
+    /// Emit a high-level `Repeat` instruction for the VM.
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        let idx = lits.len();
+        lits.push((*self.sub).clone());
+        code.push(Instr::Repeat {
+            pat_idx: idx,
+            min: self.min,
+            max: self.max,
+            mode: self.mode,
+        });
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/search_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/search_pattern.rs
@@ -1,0 +1,70 @@
+use std::cell::RefCell;
+
+use bc_components::DigestProvider;
+
+use crate::{
+    pattern::{vm::Instr, Compilable, Matcher, Path, Pattern}, EdgeType, Envelope
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct SearchPattern(Box<Pattern>);
+
+impl SearchPattern {
+    pub fn new(pattern: Pattern) -> Self { SearchPattern(Box::new(pattern)) }
+
+    pub fn pattern(&self) -> &Pattern { &self.0 }
+}
+
+impl Matcher for SearchPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        let result_paths = RefCell::new(Vec::new());
+
+        // State consists of the path from root to current node
+        let visitor = |current_envelope: &Envelope,
+                       _level: usize,
+                       _incoming_edge: EdgeType,
+                       path_to_current: Vec<Envelope>|
+         -> (Vec<Envelope>, bool) {
+            // Create the path to this node
+            let mut new_path = path_to_current.clone();
+            new_path.push(current_envelope.clone());
+
+            // Test the pattern against this node
+            let pattern_paths = self.0.paths(current_envelope);
+
+            // If the pattern matches, emit the full paths
+            for pattern_path in pattern_paths {
+                let mut full_path = new_path.clone();
+                // If the pattern path has elements beyond just the current
+                // envelope, extend with those additional
+                // elements. If the pattern path starts with the
+                // current envelope, skip it to avoid duplication.
+                if pattern_path.len() > 1 {
+                    full_path.extend(pattern_path.into_iter().skip(1));
+                } else if pattern_path.len() == 1
+                    && pattern_path[0].digest() != current_envelope.digest()
+                {
+                    // Pattern found a different element, add it to the path
+                    full_path.extend(pattern_path);
+                }
+                result_paths.borrow_mut().push(full_path);
+            }
+
+            // Continue walking with the new path
+            (new_path, false)
+        };
+
+        // Start walking from the root with an empty path
+        envelope.walk(false, Vec::new(), &visitor);
+
+        result_paths.into_inner()
+    }
+}
+
+impl Compilable for SearchPattern {
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        let idx = lits.len();
+        lits.push((*self.0).clone());
+        code.push(Instr::Search { pat_idx: idx });
+    }
+}

--- a/bc-envelope-pattern/src/pattern/meta/sequence_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/meta/sequence_pattern.rs
@@ -1,0 +1,67 @@
+use crate::{
+    Envelope,
+    pattern::{Compilable, Matcher, Path, Pattern, vm::Instr},
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct SequencePattern {
+    first: Box<Pattern>,
+    rest: Option<Box<SequencePattern>>,
+}
+
+impl SequencePattern {
+    /// Creates a new `SequencePattern` with the given patterns.
+    pub fn new(patterns: Vec<Pattern>) -> Self {
+        let mut iter = patterns.into_iter();
+        let first_pat = iter.next().unwrap_or_else(Pattern::none);
+        // Build rest as a recursive SequencePattern if more remain
+        let rest_patterns: Vec<Pattern> = iter.collect();
+        let rest = if rest_patterns.is_empty() {
+            None
+        } else {
+            Some(Box::new(SequencePattern::new(rest_patterns)))
+        };
+        SequencePattern { first: Box::new(first_pat), rest }
+    }
+}
+
+impl Matcher for SequencePattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        // Match head first
+        let head_paths = self.first.paths(envelope);
+        // If there's no further sequence, return head paths
+        if let Some(rest_seq) = &self.rest {
+            let mut result = Vec::new();
+            for path in head_paths {
+                if let Some(last_env) = path.last().cloned() {
+                    // Recursively match the rest of the sequence
+                    for tail_path in rest_seq.paths(&last_env) {
+                        let mut combined = path.clone();
+                        combined.extend(tail_path);
+                        result.push(combined);
+                    }
+                }
+            }
+            result
+        } else {
+            head_paths
+        }
+    }
+}
+
+impl Compilable for SequencePattern {
+    /// Compile into byte-code (sequential).
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        // Compile the first pattern
+        self.first.compile(code, lits);
+
+        if let Some(rest) = &self.rest {
+            // Save the current path and switch to last envelope
+            code.push(Instr::ExtendSequence);
+            // Compile the rest of the sequence
+            rest.compile(code, lits);
+            // Combine the paths correctly
+            code.push(Instr::CombineSequence);
+        }
+    }
+}

--- a/bc-envelope-pattern/src/pattern/mod.rs
+++ b/bc-envelope-pattern/src/pattern/mod.rs
@@ -1,0 +1,17 @@
+// Pattern module - provides pattern matching functionality for envelopes
+mod compile;
+mod greediness;
+mod matcher;
+mod pattern_impl;
+mod vm;
+
+// Subdirectory modules
+mod leaf;
+mod meta;
+mod structure;
+
+// Re-export all types
+pub use compile::{Compilable, compile_as_atomic};
+pub use greediness::Greediness;
+pub use matcher::{Matcher, Path};
+pub use pattern_impl::Pattern;

--- a/bc-envelope-pattern/src/pattern/pattern_impl.rs
+++ b/bc-envelope-pattern/src/pattern/pattern_impl.rs
@@ -1,0 +1,618 @@
+//! # Pattern
+//!
+//! ## Types of patterns
+//!
+//! The patterns in this crate are divided into three main categories:
+//!
+//! - **Leaf Patterns**: These patterns match specific CBOR values, such as
+//!   booleans, numbers, text, byte strings, dates, and more. They are the most
+//!   basic building blocks of the pattern system.
+//! - **Structure Patterns**: These patterns are used to match the structure of
+//!   envelopes. They can match specific structures, such as assertions,
+//!   subjects, predicates, objects, and more.
+//! - **Meta Patterns**: These patterns are used to combine and modify other
+//!   patterns. They allow you to create complex matching logic by combining
+//!   simpler patterns.
+//!
+//! ## On the difference between *regular* and *binary* regexes
+//!
+//! The text-based patterns in this crate are designed to work with the standard
+//! Rust `str` type, which is a UTF-8 encoded string. However, there are some
+//! patterns that need to work with raw bytes, such as when dealing with CBOR
+//! byte strings or envelope digests. These patterns take "binary regexes".
+//! There are some operational differences between the two types of regexes,
+//! which are summarized in the table below.
+//!
+//! | concern                           | Text Regex                                                                                                                                                                           | Binary Regex                                                                                                                                                                             |
+//! | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+//! | **Haystack & captures**           | Works on `&str` / `String`; captures are `&str`.                                                                                                                                     | Works on `&[u8]` / `Vec<u8>`; captures are `&[u8]`. That means you can safely search data that is **not valid UTF-8**. ([docs.rs][1])                                                    |
+//! | **Fundamental matching unit**     | By default the engine iterates over **Unicode scalar values** (code-points). `.` matches an entire code-point, even if it takes multiple bytes in UTF-8. ([docs.rs][2])              | When the `u` flag is disabled the engine iterates **byte-by-byte**; `.` then matches exactly one byte. (With `u` on, it behaves like the text engine.) ([docs.rs][2])                    |
+//! | **Turning Unicode off (`(?-u)`)** | Allowed **only** when the resulting pattern still can’t match invalid UTF-8—e.g. `(?-u:\w)` is OK, `(?-u:\xFF)` is *rejected*. This preserves Rust’s `str` invariant. ([docs.rs][2]) | You can disable `u` anywhere, even if that lets the regex match arbitrary byte values such as `\x00` or `\xFF`. This is the big operational freedom “binary” regexes add. ([docs.rs][1]) |
+//! | **Empty-string matches**          | Guaranteed **not** to split a UTF-8 code-point; you’ll see at most one empty match between code-points.                                                                              | May report an empty match **between every byte** (because bytes are the atom). ([docs.rs][2])                                                                                            |
+//! | **Typical use-cases**             | Validating/processing normal text, log files, config files…                                                                                                                          | Packet inspection, parsing binary protocols, scanning blobs that may embed non-UTF-8 data, digging NUL-terminated C strings in memory dumps, etc.                                        |
+//!
+//! ### Example
+//!
+//! A binary regex matching any byte string ending with h'010203':
+//!
+//! ```text
+//! (?s-u).*\x01\x02\x03$
+//! ```
+//!
+//! Note:
+//!
+//! - The `(?s-u)` enables the "dot matches newline" mode, allowing `.` to match
+//!   across newlines, and disables Unicode mode, allowing `.` to match any byte
+//!   value.
+//! - The hexadecimal bytes values must each be prefixed with `\x`.
+//!
+//! ### References
+//!
+//! - https://docs.rs/regex/latest/regex/bytes/index.html "regex::bytes - Rust"
+//! - https://docs.rs/regex/latest/regex/ "regex - Rust"
+
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    ops::{Bound, RangeBounds, RangeInclusive},
+};
+
+use dcbor::prelude::*;
+use known_values::KnownValue;
+
+use super::leaf::KnownValuePattern;
+use super::{
+    Greediness, Matcher, Path,
+    leaf::{
+        ArrayPattern, BoolPattern, ByteStringPattern, DatePattern, LeafPattern,
+        MapPattern, NullPattern, NumberPattern, TaggedPattern, TextPattern,
+    },
+    meta::{
+        AndPattern, CapturePattern, MetaPattern, NotPattern, OrPattern,
+        RepeatPattern, SearchPattern, SequencePattern,
+    },
+    structure::{
+        AssertionsPattern, DigestPattern, NodePattern, ObjectPattern,
+        ObscuredPattern, PredicatePattern, StructurePattern, SubjectPattern,
+        WrappedPattern,
+    },
+    vm,
+};
+use crate::{
+    Envelope,
+    pattern::{
+        Compilable,
+        leaf::CBORPattern,
+        meta::{AnyPattern, NonePattern},
+        vm::Instr,
+    },
+};
+
+/// The main pattern type used for matching envelopes.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum Pattern {
+    /// Leaf patterns for matching CBOR values.
+    Leaf(LeafPattern),
+
+    /// Structure patterns for matching envelope elements.
+    Structure(StructurePattern),
+
+    /// Meta-patterns for combining and modifying other patterns.
+    Meta(MetaPattern),
+}
+
+impl Matcher for Pattern {
+    fn paths(&self, env: &Envelope) -> Vec<Path> {
+        thread_local! {
+            static PROG: RefCell<HashMap<u64, vm::Program>> = RefCell::new(HashMap::new());
+        }
+
+        // cheap structural hash
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
+        let mut h = DefaultHasher::new();
+        self.hash(&mut h);
+        let key = h.finish();
+
+        let prog = PROG
+            .with(|cell| cell.borrow().get(&key).cloned())
+            .unwrap_or_else(|| {
+                let mut p =
+                    vm::Program { code: Vec::new(), literals: Vec::new() };
+                self.compile(&mut p.code, &mut p.literals);
+                p.code.push(Instr::Accept);
+                PROG.with(|cell| {
+                    cell.borrow_mut().insert(key, p.clone());
+                });
+                p
+            });
+
+        vm::run(&prog, env)
+    }
+}
+
+// region: Leaf Patterns
+//
+//
+
+impl Pattern {
+    /// Creates a new `Pattern` that matches any CBOR value.
+    pub fn any_cbor() -> Self {
+        Pattern::Leaf(LeafPattern::Cbor(CBORPattern::any()))
+    }
+
+    /// Creates a new `Pattern` that matches a specific CBOR value.
+    pub fn cbor(cbor: CBOR) -> Self {
+        Pattern::Leaf(LeafPattern::Cbor(CBORPattern::exact(cbor)))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that matches any boolean value.
+    pub fn any_bool() -> Self {
+        Pattern::Leaf(LeafPattern::Bool(BoolPattern::any()))
+    }
+
+    /// Creates a new `Pattern` that matches a specific boolean value.
+    pub fn bool(b: bool) -> Self {
+        Pattern::Leaf(LeafPattern::Bool(BoolPattern::exact(b)))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that matches any text value.
+    pub fn any_text() -> Self {
+        Pattern::Leaf(LeafPattern::Text(TextPattern::any()))
+    }
+
+    /// Creates a new `Pattern` that matches a specific text value.
+    pub fn text<T: Into<String>>(value: T) -> Self {
+        Pattern::Leaf(LeafPattern::Text(TextPattern::exact(value)))
+    }
+
+    /// Creates a new `Pattern` that matches text values that match the given
+    /// regular expression.
+    pub fn text_regex(regex: regex::Regex) -> Self {
+        Pattern::Leaf(LeafPattern::Text(TextPattern::regex(regex)))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that matches any Date (CBOR tag 1) value.
+    pub fn any_date() -> Self {
+        Pattern::Leaf(LeafPattern::Date(DatePattern::any()))
+    }
+
+    /// Creates a new `Pattern` that matches a specific Date (CBOR tag 1) value.
+    pub fn date(date: dcbor::Date) -> Self {
+        Pattern::Leaf(LeafPattern::Date(DatePattern::date(date)))
+    }
+
+    /// Creates a new `Pattern` that matches Date (CBOR tag 1) values within a
+    /// specified range (inclusive).
+    pub fn date_range(range: RangeInclusive<dcbor::Date>) -> Self {
+        Pattern::Leaf(LeafPattern::Date(DatePattern::range(range)))
+    }
+
+    /// Creates a new `Pattern` that matches Date (CBOR tag 1) values that are
+    /// on or after the specified date.
+    pub fn date_earliest(date: dcbor::Date) -> Self {
+        Pattern::Leaf(LeafPattern::Date(DatePattern::earliest(date)))
+    }
+
+    /// Creates a new `Pattern` that matches Date (CBOR tag 1) values that are
+    /// on or before the specified date.
+    pub fn date_latest(date: dcbor::Date) -> Self {
+        Pattern::Leaf(LeafPattern::Date(DatePattern::latest(date)))
+    }
+
+    /// Creates a new `Pattern` that matches Date (CBOR tag 1) values by their
+    /// ISO-8601 string representation.
+    pub fn date_iso8601(iso_string: impl Into<String>) -> Self {
+        Pattern::Leaf(LeafPattern::Date(DatePattern::iso8601(iso_string)))
+    }
+
+    /// Creates a new `Pattern` that matches Date (CBOR tag 1) values whose
+    /// ISO-8601 string representation matches the given regular expression.
+    pub fn date_regex(regex: regex::Regex) -> Self {
+        Pattern::Leaf(LeafPattern::Date(DatePattern::regex(regex)))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that matches any number value.
+    pub fn any_number() -> Self {
+        Pattern::Leaf(LeafPattern::Number(NumberPattern::any()))
+    }
+
+    /// Creates a new `Pattern` that matches a specific number value.
+    pub fn number<T: Into<f64>>(value: T) -> Self {
+        Pattern::Leaf(LeafPattern::Number(NumberPattern::exact(value)))
+    }
+
+    /// Creates a new `Pattern` that matches number values within a specified
+    /// range (inclusive).
+    pub fn number_range<A: Into<f64> + Copy>(range: RangeInclusive<A>) -> Self {
+        Pattern::Leaf(LeafPattern::Number(NumberPattern::range(range)))
+    }
+
+    /// Creates a new `Pattern` that matches number values that are greater than
+    /// the specified value.
+    pub fn number_greater_than<T: Into<f64>>(value: T) -> Self {
+        Pattern::Leaf(LeafPattern::Number(NumberPattern::greater_than(value)))
+    }
+
+    /// Creates a new `Pattern` that matches number values that are greater than
+    /// or equal to the specified value.
+    pub fn number_greater_than_or_equal<T: Into<f64>>(value: T) -> Self {
+        Pattern::Leaf(LeafPattern::Number(
+            NumberPattern::greater_than_or_equal(value),
+        ))
+    }
+
+    /// Creates a new `Pattern` that matches number values that are less than
+    /// the specified value.
+    pub fn number_less_than<T: Into<f64>>(value: T) -> Self {
+        Pattern::Leaf(LeafPattern::Number(NumberPattern::less_than(value)))
+    }
+
+    /// Creates a new `Pattern` that matches number values that are less than or
+    /// equal to the specified value.
+    pub fn number_less_than_or_equal<T: Into<f64>>(value: T) -> Self {
+        Pattern::Leaf(LeafPattern::Number(NumberPattern::less_than_or_equal(
+            value,
+        )))
+    }
+
+    /// Creates a new `Pattern` that matches number values that are NaN (Not a
+    /// Number).
+    pub fn number_nan() -> Self {
+        Pattern::Leaf(LeafPattern::Number(NumberPattern::nan()))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that matches any byte string value.
+    pub fn any_byte_string() -> Self {
+        Pattern::Leaf(LeafPattern::ByteString(ByteStringPattern::any()))
+    }
+
+    /// Creates a new `Pattern` that matches a specific byte string value.
+    pub fn byte_string(value: impl AsRef<[u8]>) -> Self {
+        Pattern::Leaf(LeafPattern::ByteString(ByteStringPattern::exact(value)))
+    }
+
+    /// Creates a new `Pattern` that matches byte string values that match the
+    /// given binary regular expression.
+    pub fn byte_string_binary_regex(regex: regex::bytes::Regex) -> Self {
+        Pattern::Leaf(LeafPattern::ByteString(ByteStringPattern::binary_regex(
+            regex,
+        )))
+    }
+}
+
+impl Pattern {
+    pub fn any_known_value() -> Self {
+        Pattern::Leaf(LeafPattern::KnownValue(KnownValuePattern::any()))
+    }
+
+    pub fn known_value(value: KnownValue) -> Self {
+        Pattern::Leaf(LeafPattern::KnownValue(KnownValuePattern::known_value(
+            value,
+        )))
+    }
+
+    pub fn known_value_named<T: Into<String>>(name: T) -> Self {
+        Pattern::Leaf(LeafPattern::KnownValue(KnownValuePattern::named(name)))
+    }
+
+    pub fn known_value_regex(regex: regex::Regex) -> Self {
+        Pattern::Leaf(LeafPattern::KnownValue(KnownValuePattern::regex(regex)))
+    }
+
+    pub fn unit() -> Self { Self::known_value(known_values::UNIT) }
+}
+
+impl Pattern {
+    pub fn any_array() -> Self {
+        Pattern::Leaf(LeafPattern::Array(ArrayPattern::any()))
+    }
+
+    pub fn array_count(count: usize) -> Self {
+        Pattern::Leaf(LeafPattern::Array(ArrayPattern::count(count)))
+    }
+
+    pub fn array_count_range(range: RangeInclusive<usize>) -> Self {
+        Pattern::Leaf(LeafPattern::Array(ArrayPattern::range_count(range)))
+    }
+}
+
+impl Pattern {
+    pub fn any_map() -> Self {
+        Pattern::Leaf(LeafPattern::Map(MapPattern::any()))
+    }
+
+    pub fn map_count(count: usize) -> Self {
+        Pattern::Leaf(LeafPattern::Map(MapPattern::count(count)))
+    }
+
+    pub fn map_count_range(range: RangeInclusive<usize>) -> Self {
+        Pattern::Leaf(LeafPattern::Map(MapPattern::range_count(range)))
+    }
+}
+
+impl Pattern {
+    pub fn null() -> Self {
+        Pattern::Leaf(LeafPattern::Null(NullPattern::any()))
+    }
+}
+
+impl Pattern {
+    pub fn any_tag() -> Self {
+        Pattern::Leaf(LeafPattern::Tag(TaggedPattern::any()))
+    }
+
+    pub fn tagged(tag: dcbor::Tag) -> Self {
+        Pattern::Leaf(LeafPattern::Tag(TaggedPattern::with_tag(tag)))
+    }
+
+    pub fn tagged_with_value(value: u64) -> Self {
+        Pattern::Leaf(LeafPattern::Tag(TaggedPattern::with_tag_value(value)))
+    }
+
+    pub fn tagged_with_name(name: impl Into<String>) -> Self {
+        Pattern::Leaf(LeafPattern::Tag(TaggedPattern::with_tag_name(name)))
+    }
+
+    pub fn tagged_with_regex(regex: regex::Regex) -> Self {
+        Pattern::Leaf(LeafPattern::Tag(TaggedPattern::with_tag_regex(regex)))
+    }
+}
+
+//
+//
+// endregion
+
+// region: Structure Patterns
+//
+//
+
+impl Pattern {
+    pub fn wrapped() -> Self {
+        Pattern::Structure(StructurePattern::wrapped(WrappedPattern::any()))
+    }
+}
+
+impl Pattern {
+    pub fn any_assertion() -> Self {
+        Pattern::Structure(StructurePattern::assertions(
+            AssertionsPattern::any(),
+        ))
+    }
+
+    pub fn assertion_with_predicate(pattern: Pattern) -> Self {
+        Pattern::Structure(StructurePattern::assertions(
+            AssertionsPattern::with_predicate(pattern),
+        ))
+    }
+
+    pub fn assertion_with_object(pattern: Pattern) -> Self {
+        Pattern::Structure(StructurePattern::assertions(
+            AssertionsPattern::with_object(pattern),
+        ))
+    }
+}
+
+impl Pattern {
+    pub fn subject() -> Self {
+        Pattern::Structure(StructurePattern::subject(SubjectPattern::any()))
+    }
+
+    pub fn any_predicate() -> Self {
+        Pattern::Structure(StructurePattern::predicate(PredicatePattern::any()))
+    }
+
+    pub fn predicate(pattern: Pattern) -> Self {
+        Pattern::Structure(StructurePattern::predicate(
+            PredicatePattern::pattern(pattern),
+        ))
+    }
+
+    pub fn any_object() -> Self {
+        Pattern::Structure(StructurePattern::object(ObjectPattern::any()))
+    }
+
+    pub fn object(pattern: Pattern) -> Self {
+        Pattern::Structure(StructurePattern::object(ObjectPattern::pattern(
+            pattern,
+        )))
+    }
+}
+
+impl Pattern {
+    pub fn digest(digest: bc_components::Digest) -> Self {
+        Pattern::Structure(StructurePattern::digest(DigestPattern::digest(
+            digest,
+        )))
+    }
+
+    pub fn digest_hex_prefix<T: Into<String>>(prefix: T) -> Self {
+        Pattern::Structure(StructurePattern::digest(DigestPattern::hex_prefix(
+            prefix,
+        )))
+    }
+
+    pub fn digest_binary_regex(regex: regex::bytes::Regex) -> Self {
+        Pattern::Structure(StructurePattern::digest(
+            DigestPattern::binary_regex(regex),
+        ))
+    }
+
+    pub fn any_node() -> Self {
+        Pattern::Structure(StructurePattern::node(NodePattern::any()))
+    }
+
+    pub fn node_with_assertions_count_range(
+        range: RangeInclusive<usize>,
+    ) -> Self {
+        Pattern::Structure(StructurePattern::node(
+            NodePattern::assertions_count_range(range),
+        ))
+    }
+
+    pub fn node_with_assertions_count(count: usize) -> Self {
+        Pattern::Structure(StructurePattern::node(
+            NodePattern::assertions_count(count),
+        ))
+    }
+
+    pub fn obscured() -> Self {
+        Pattern::Structure(StructurePattern::obscured(ObscuredPattern::any()))
+    }
+
+    pub fn elided() -> Self {
+        Pattern::Structure(
+            StructurePattern::obscured(ObscuredPattern::elided()),
+        )
+    }
+
+    pub fn encrypted() -> Self {
+        Pattern::Structure(StructurePattern::obscured(
+            ObscuredPattern::encrypted(),
+        ))
+    }
+
+    pub fn compressed() -> Self {
+        Pattern::Structure(StructurePattern::obscured(
+            ObscuredPattern::compressed(),
+        ))
+    }
+}
+
+//
+//
+// endregion
+
+// region: Meta Patterns
+//
+//
+
+impl Pattern {
+    /// Creates a new `Pattern` that matches any element.
+    pub fn any() -> Self { Pattern::Meta(MetaPattern::Any(AnyPattern::new())) }
+
+    /// Creates a new `Pattern` that never matches any element.
+    pub fn none() -> Self {
+        Pattern::Meta(MetaPattern::None(NonePattern::new()))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that only matches if all specified patterns
+    /// match.
+    pub fn and(patterns: Vec<Pattern>) -> Self {
+        Pattern::Meta(MetaPattern::and(AndPattern::new(patterns)))
+    }
+
+    /// Creates a new `Pattern` that matches if at least one of the specified
+    /// patterns matches.
+    pub fn or(patterns: Vec<Pattern>) -> Self {
+        Pattern::Meta(MetaPattern::or(OrPattern::new(patterns)))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that matches a sequence of patterns in order.
+    pub fn sequence(patterns: Vec<Pattern>) -> Self {
+        Pattern::Meta(MetaPattern::sequence(SequencePattern::new(patterns)))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that searches for a specific pattern within the
+    /// envelope. Useful for finding patterns that may not be at the root
+    /// of the envelope.
+    pub fn search(pattern: Pattern) -> Self {
+        Pattern::Meta(MetaPattern::search(SearchPattern::new(pattern)))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that negates another pattern; matches if the
+    /// specified pattern does not match.
+    pub fn not_matching(pattern: Pattern) -> Self {
+        Pattern::Meta(MetaPattern::not(NotPattern::new(pattern)))
+    }
+}
+
+impl Pattern {
+    /// Compile self to byte-code (recursive).
+    pub(crate) fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+    ) {
+        use Pattern::*;
+        match self {
+            Leaf(leaf_pattern) => leaf_pattern.compile(code, lits),
+            Structure(struct_pattern) => struct_pattern.compile(code, lits),
+            Meta(meta_pattern) => meta_pattern.compile(code, lits),
+        }
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that will match a pattern repeated a number of
+    /// times according to the specified range and greediness.
+    ///
+    /// In regex terms:
+    ///
+    /// | Range         | Quantifier   |
+    /// | :------------ | :----------- |
+    /// | `..`          | `*`          |
+    /// | `1..`         | `+`          |
+    /// | `0..=1`       | `?`          |
+    /// | `min..=max`   | `{min,max}`  |
+    /// | `min..`       | `{min,}`     |
+    /// | `..=max`      | `{0,max}`    |
+    /// | `n..=n`       | `{n}`        |
+    pub fn repeat<R>(pattern: Pattern, range: R, mode: Greediness) -> Self
+    where
+        R: RangeBounds<usize>,
+    {
+        let min = match range.start_bound() {
+            Bound::Included(&n) => n,
+            Bound::Excluded(&n) => n + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let max = match range.end_bound() {
+            Bound::Included(&n) => Some(n),
+            Bound::Excluded(&n) => Some(n - 1),
+            Bound::Unbounded => None,
+        };
+
+        Pattern::Meta(MetaPattern::Repeat(RepeatPattern {
+            sub: Box::new(pattern),
+            min,
+            max,
+            mode,
+        }))
+    }
+}
+
+impl Pattern {
+    /// Creates a new `Pattern` that will capture a pattern match with a name.
+    pub fn capture(name: &str, pattern: Pattern) -> Self {
+        Pattern::Meta(MetaPattern::Capture(CapturePattern {
+            name: name.to_string(),
+            inner: Box::new(pattern),
+        }))
+    }
+}
+
+//
+//
+// endregion

--- a/bc-envelope-pattern/src/pattern/structure/assertions_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/assertions_pattern.rs
@@ -1,0 +1,72 @@
+use crate::{
+    Envelope,
+    pattern::{
+        Compilable, Matcher, Path, Pattern, structure::StructurePattern,
+        vm::Instr,
+    },
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum AssertionsPattern {
+    /// Matches any assertion.
+    Any,
+    /// Matches assertions with predicates that match a specific pattern.
+    WithPredicate(Box<Pattern>),
+    /// Matches assertions with objects that match a specific pattern.
+    WithObject(Box<Pattern>),
+}
+
+impl AssertionsPattern {
+    /// Creates a new `AssertionsPattern` that matches any assertion.
+    pub fn any() -> Self { AssertionsPattern::Any }
+
+    /// Creates a new `AssertionsPattern` that matches assertions
+    /// with predicates that match a specific pattern.
+    pub fn with_predicate(pattern: Pattern) -> Self {
+        AssertionsPattern::WithPredicate(Box::new(pattern))
+    }
+
+    /// Creates a new `AssertionsPattern` that matches
+    /// assertions with objects that match a specific pattern.
+    pub fn with_object(pattern: Pattern) -> Self {
+        AssertionsPattern::WithObject(Box::new(pattern))
+    }
+}
+
+impl Matcher for AssertionsPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        let mut result = Vec::new();
+        for assertion in envelope.assertions() {
+            match self {
+                AssertionsPattern::Any => {
+                    result.push(vec![assertion.clone()]);
+                }
+                AssertionsPattern::WithPredicate(pattern) => {
+                    if let Some(predicate) = assertion.as_predicate() {
+                        if pattern.matches(&predicate) {
+                            result.push(vec![assertion.clone()]);
+                        }
+                    }
+                }
+                AssertionsPattern::WithObject(pattern) => {
+                    if let Some(object) = assertion.as_object() {
+                        if pattern.matches(&object) {
+                            result.push(vec![assertion.clone()]);
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+}
+
+impl Compilable for AssertionsPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        let idx = literals.len();
+        literals.push(Pattern::Structure(
+            StructurePattern::Assertions(self.clone()),
+        ));
+        code.push(Instr::MatchStructure(idx));
+    }
+}

--- a/bc-envelope-pattern/src/pattern/structure/digest_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/digest_pattern.rs
@@ -1,0 +1,103 @@
+use bc_components::{Digest, DigestProvider};
+
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path, compile_as_atomic,
+        structure::StructurePattern, vm::Instr,
+    },
+};
+
+/// Pattern for matching envelopes by their digest.
+#[derive(Debug, Clone)]
+pub enum DigestPattern {
+    /// Matches the exact digest.
+    Digest(Digest),
+    /// Matches the hexadecimal prefix of a digest (case insensitive).
+    HexPrefix(String),
+    /// Matches the binary regular expression for a digest.
+    BinaryRegex(regex::bytes::Regex),
+}
+
+impl PartialEq for DigestPattern {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (DigestPattern::Digest(a), DigestPattern::Digest(b)) => a == b,
+            (DigestPattern::HexPrefix(a), DigestPattern::HexPrefix(b)) => {
+                a.eq_ignore_ascii_case(b)
+            }
+            (DigestPattern::BinaryRegex(a), DigestPattern::BinaryRegex(b)) => {
+                a.as_str() == b.as_str()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for DigestPattern {}
+
+impl std::hash::Hash for DigestPattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            DigestPattern::Digest(a) => {
+                0u8.hash(state);
+                a.hash(state);
+            }
+            DigestPattern::HexPrefix(prefix) => {
+                1u8.hash(state);
+                prefix.to_lowercase().hash(state);
+            }
+            DigestPattern::BinaryRegex(regex) => {
+                2u8.hash(state);
+                // Regex does not implement Hash, so we hash its pattern string.
+                regex.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl DigestPattern {
+    /// Creates a new `DigestPattern` that matches the exact digest.
+    pub fn digest(digest: Digest) -> Self { DigestPattern::Digest(digest) }
+
+    /// Creates a new `DigestPattern` that matches the hexadecimal prefix of a
+    /// digest.
+    pub fn hex_prefix(prefix: impl Into<String>) -> Self {
+        DigestPattern::HexPrefix(prefix.into())
+    }
+
+    /// Creates a new `DigestPattern` that matches the binary regex for a
+    /// digest.
+    pub fn binary_regex(regex: regex::bytes::Regex) -> Self {
+        DigestPattern::BinaryRegex(regex)
+    }
+}
+
+impl Matcher for DigestPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        let digest = envelope.digest();
+        let is_hit = match self {
+            DigestPattern::Digest(pattern_digest) => *pattern_digest == *digest,
+            DigestPattern::HexPrefix(prefix) => {
+                hex::encode(digest.data()).starts_with(&prefix.to_lowercase())
+            }
+            DigestPattern::BinaryRegex(regex) => regex.is_match(digest.data()),
+        };
+
+        if is_hit {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for DigestPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Structure(StructurePattern::Digest(self.clone())),
+            code,
+            literals,
+        );
+    }
+}

--- a/bc-envelope-pattern/src/pattern/structure/mod.rs
+++ b/bc-envelope-pattern/src/pattern/structure/mod.rs
@@ -1,0 +1,21 @@
+// Structure patterns - patterns dealing with envelope structure
+
+mod assertions_pattern;
+mod digest_pattern;
+mod node_pattern;
+mod object_pattern;
+mod obscured_pattern;
+mod predicate_pattern;
+mod structure_pattern;
+mod subject_pattern;
+mod wrapped_pattern;
+
+pub(crate) use assertions_pattern::AssertionsPattern;
+pub(crate) use digest_pattern::DigestPattern;
+pub(crate) use node_pattern::NodePattern;
+pub(crate) use object_pattern::ObjectPattern;
+pub(crate) use obscured_pattern::ObscuredPattern;
+pub(crate) use predicate_pattern::PredicatePattern;
+pub(crate) use structure_pattern::StructurePattern;
+pub(crate) use subject_pattern::SubjectPattern;
+pub(crate) use wrapped_pattern::WrappedPattern;

--- a/bc-envelope-pattern/src/pattern/structure/node_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/node_pattern.rs
@@ -1,0 +1,62 @@
+use std::ops::RangeInclusive;
+
+use crate::{
+    pattern::{compile_as_atomic, structure::StructurePattern, vm::Instr, Compilable, Matcher, Path}, Envelope, Pattern
+};
+
+/// Pattern for matching node envelopes.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum NodePattern {
+    /// Matches any node.
+    Any,
+    /// Matches a node with the specified count of assertions.
+    AssertionsCount(RangeInclusive<usize>),
+}
+
+impl NodePattern {
+    /// Creates a new `NodePattern` that matches any node.
+    pub fn any() -> Self { NodePattern::Any }
+
+    /// Creates a new `NodePattern` that matches a node with the specified count
+    /// of assertions.
+    pub fn assertions_count_range(range: RangeInclusive<usize>) -> Self {
+        NodePattern::AssertionsCount(range)
+    }
+
+    /// Creates a new `NodePattern` that matches a node with exactly the
+    /// specified number of assertions.
+    pub fn assertions_count(count: usize) -> Self {
+        NodePattern::AssertionsCount(count..=count)
+    }
+}
+
+impl Matcher for NodePattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if !envelope.is_node() {
+            return vec![];
+        }
+
+        let is_hit = match self {
+            NodePattern::Any => true,
+            NodePattern::AssertionsCount(range) => {
+                range.contains(&envelope.assertions().len())
+            }
+        };
+
+        if is_hit {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for NodePattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Structure(StructurePattern::Node(self.clone())),
+            code,
+            literals,
+        );
+    }
+}

--- a/bc-envelope-pattern/src/pattern/structure/object_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/object_pattern.rs
@@ -1,0 +1,51 @@
+use crate::{
+    Envelope,
+    pattern::{
+        Compilable, Matcher, Path, Pattern, structure::StructurePattern,
+        vm::Instr,
+    },
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum ObjectPattern {
+    Any,
+    Pattern(Box<Pattern>),
+}
+
+impl ObjectPattern {
+    pub fn any() -> Self { ObjectPattern::Any }
+
+    pub fn pattern(pattern: Pattern) -> Self {
+        ObjectPattern::Pattern(Box::new(pattern))
+    }
+}
+
+impl Matcher for ObjectPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if let Some(object) = envelope.as_object() {
+            match self {
+                ObjectPattern::Any => {
+                    vec![vec![object.clone()]]
+                }
+                ObjectPattern::Pattern(pattern) => {
+                    if pattern.matches(&object) {
+                        vec![vec![object.clone()]]
+                    } else {
+                        vec![]
+                    }
+                }
+            }
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for ObjectPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        let idx = literals.len();
+        literals
+            .push(Pattern::Structure(StructurePattern::Object(self.clone())));
+        code.push(Instr::MatchStructure(idx));
+    }
+}

--- a/bc-envelope-pattern/src/pattern/structure/obscured_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/obscured_pattern.rs
@@ -1,0 +1,61 @@
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path, compile_as_atomic,
+        structure::StructurePattern, vm::Instr,
+    },
+};
+
+/// Pattern for matching obscured elements.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum ObscuredPattern {
+    /// Matches any obscured element.
+    Any,
+    /// Matches any elided element.
+    Elided,
+    /// Matches any encrypted element.
+    Encrypted,
+    /// Matches any compressed element.
+    Compressed,
+}
+
+impl ObscuredPattern {
+    /// Creates a new `ObscuredPattern` that matches any obscured element.
+    pub fn any() -> Self { ObscuredPattern::Any }
+
+    /// Creates a new `ObscuredPattern` that matches any elided element.
+    pub fn elided() -> Self { ObscuredPattern::Elided }
+
+    /// Creates a new `ObscuredPattern` that matches any encrypted element.
+    pub fn encrypted() -> Self { ObscuredPattern::Encrypted }
+
+    /// Creates a new `ObscuredPattern` that matches any compressed element.
+    pub fn compressed() -> Self { ObscuredPattern::Compressed }
+}
+
+impl Matcher for ObscuredPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        let is_hit = match self {
+            ObscuredPattern::Any => envelope.is_obscured(),
+            ObscuredPattern::Elided => envelope.is_elided(),
+            ObscuredPattern::Encrypted => envelope.is_encrypted(),
+            ObscuredPattern::Compressed => envelope.is_compressed(),
+        };
+
+        if is_hit {
+            vec![vec![envelope.clone()]]
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for ObscuredPattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        compile_as_atomic(
+            &Pattern::Structure(StructurePattern::Obscured(self.clone())),
+            code,
+            literals,
+        );
+    }
+}

--- a/bc-envelope-pattern/src/pattern/structure/predicate_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/predicate_pattern.rs
@@ -1,0 +1,52 @@
+use crate::{
+    Envelope,
+    pattern::{
+        Compilable, Matcher, Path, Pattern, structure::StructurePattern,
+        vm::Instr,
+    },
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum PredicatePattern {
+    Any,
+    Pattern(Box<Pattern>),
+}
+
+impl PredicatePattern {
+    pub fn any() -> Self { PredicatePattern::Any }
+
+    pub fn pattern(pattern: Pattern) -> Self {
+        PredicatePattern::Pattern(Box::new(pattern))
+    }
+}
+
+impl Matcher for PredicatePattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        if let Some(predicate) = envelope.as_predicate() {
+            match self {
+                PredicatePattern::Any => {
+                    vec![vec![predicate.clone()]]
+                }
+                PredicatePattern::Pattern(pattern) => {
+                    if pattern.matches(&predicate) {
+                        vec![vec![predicate.clone()]]
+                    } else {
+                        vec![]
+                    }
+                }
+            }
+        } else {
+            vec![]
+        }
+    }
+}
+
+impl Compilable for PredicatePattern {
+    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+        let idx = literals.len();
+        literals.push(Pattern::Structure(StructurePattern::Predicate(
+            self.clone(),
+        )));
+        code.push(Instr::MatchStructure(idx));
+    }
+}

--- a/bc-envelope-pattern/src/pattern/structure/structure_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/structure_pattern.rs
@@ -1,0 +1,93 @@
+use super::{
+    AssertionsPattern, DigestPattern, NodePattern, ObjectPattern,
+    ObscuredPattern, PredicatePattern, SubjectPattern, WrappedPattern,
+};
+use crate::{
+    Envelope,
+    pattern::{Compilable, Matcher, Path, Pattern, vm::Instr},
+};
+
+/// Pattern for matching envelope structure elements.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum StructurePattern {
+    /// Matches assertions.
+    Assertions(AssertionsPattern),
+    /// Matches digests.
+    Digest(DigestPattern),
+    /// Matches nodes.
+    Node(NodePattern),
+    /// Matches objects.
+    Object(ObjectPattern),
+    /// Matches obscured elements.
+    Obscured(ObscuredPattern),
+    /// Matches predicates.
+    Predicate(PredicatePattern),
+    /// Matches subjects.
+    Subject(SubjectPattern),
+    /// Matches wrapped envelopes.
+    Wrapped(WrappedPattern),
+}
+
+impl StructurePattern {
+    pub fn assertions(pattern: AssertionsPattern) -> Self {
+        StructurePattern::Assertions(pattern)
+    }
+
+    pub fn digest(pattern: DigestPattern) -> Self {
+        StructurePattern::Digest(pattern)
+    }
+
+    pub fn node(pattern: NodePattern) -> Self {
+        StructurePattern::Node(pattern)
+    }
+
+    pub fn object(pattern: ObjectPattern) -> Self {
+        StructurePattern::Object(pattern)
+    }
+
+    pub fn obscured(pattern: ObscuredPattern) -> Self {
+        StructurePattern::Obscured(pattern)
+    }
+
+    pub fn predicate(pattern: PredicatePattern) -> Self {
+        StructurePattern::Predicate(pattern)
+    }
+
+    pub fn subject(pattern: SubjectPattern) -> Self {
+        StructurePattern::Subject(pattern)
+    }
+
+    pub fn wrapped(pattern: WrappedPattern) -> Self {
+        StructurePattern::Wrapped(pattern)
+    }
+}
+
+impl Matcher for StructurePattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        match self {
+            StructurePattern::Assertions(pattern) => pattern.paths(envelope),
+            StructurePattern::Digest(pattern) => pattern.paths(envelope),
+            StructurePattern::Node(pattern) => pattern.paths(envelope),
+            StructurePattern::Object(pattern) => pattern.paths(envelope),
+            StructurePattern::Obscured(pattern) => pattern.paths(envelope),
+            StructurePattern::Predicate(pattern) => pattern.paths(envelope),
+            StructurePattern::Subject(pattern) => pattern.paths(envelope),
+            StructurePattern::Wrapped(pattern) => pattern.paths(envelope),
+        }
+    }
+}
+
+impl Compilable for StructurePattern {
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        match self {
+            StructurePattern::Subject(s) => s.compile(code, lits),
+            StructurePattern::Assertions(s) => s.compile(code, lits),
+            StructurePattern::Wrapped(s) => s.compile(code, lits),
+            StructurePattern::Object(s) => s.compile(code, lits),
+            StructurePattern::Digest(s) => s.compile(code, lits),
+            StructurePattern::Node(s) => s.compile(code, lits),
+            StructurePattern::Obscured(s) => s.compile(code, lits),
+            StructurePattern::Predicate(s) => s.compile(code, lits),
+        }
+    }
+}

--- a/bc-envelope-pattern/src/pattern/structure/subject_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/subject_pattern.rs
@@ -1,0 +1,33 @@
+use crate::{
+    Envelope,
+    pattern::{Compilable, Matcher, Path, Pattern, vm::Instr},
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum SubjectPattern {
+    Any,
+}
+
+impl SubjectPattern {
+    pub fn any() -> Self { SubjectPattern::Any }
+}
+
+impl Compilable for SubjectPattern {
+    fn compile(&self, code: &mut Vec<Instr>, _lits: &mut Vec<Pattern>) {
+        match self {
+            SubjectPattern::Any => {
+                code.push(Instr::NavigateSubject);
+            }
+        }
+    }
+}
+
+impl Matcher for SubjectPattern {
+    fn paths(&self, env: &Envelope) -> Vec<Path> {
+        if env.is_node() {
+            vec![vec![env.subject().clone()]]
+        } else {
+            vec![vec![]]
+        }
+    }
+}

--- a/bc-envelope-pattern/src/pattern/structure/wrapped_pattern.rs
+++ b/bc-envelope-pattern/src/pattern/structure/wrapped_pattern.rs
@@ -1,0 +1,49 @@
+use crate::{
+    Envelope, Pattern,
+    pattern::{
+        Compilable, Matcher, Path,
+        structure::StructurePattern,
+        vm::{Axis, Instr},
+    },
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum WrappedPattern {
+    /// Matches any wrapped envelope.
+    Any,
+}
+
+impl WrappedPattern {
+    /// Creates a new `WrappedPattern` that matches any wrapped envelope.
+    pub fn any() -> Self { WrappedPattern::Any }
+}
+
+impl Compilable for WrappedPattern {
+    /// Emit predicate + descent so the VM makes progress.
+    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+        // println!("Compiling WrappedPattern: {:?}", self);
+        // 1) atomic predicate “is wrapped”
+        let idx = lits.len();
+        lits.push(Pattern::Structure(StructurePattern::wrapped(self.clone())));
+        code.push(Instr::MatchStructure(idx));
+
+        // 2) then move into inner envelope
+        code.push(Instr::PushAxis(Axis::Wrapped));
+    }
+}
+
+impl Matcher for WrappedPattern {
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        // println!("Matching WrappedPattern: {:?}", self);
+        let subject = envelope.subject();
+        if subject.is_wrapped() {
+            match self {
+                WrappedPattern::Any => {
+                    vec![vec![envelope.clone()]]
+                }
+            }
+        } else {
+            vec![]
+        }
+    }
+}

--- a/bc-envelope-pattern/src/pattern/vm.rs
+++ b/bc-envelope-pattern/src/pattern/vm.rs
@@ -1,0 +1,501 @@
+//! Tiny Thompson-style VM for walking Gordian Envelope trees.
+//!
+//! The VM runs byte-code produced by `Pattern::compile` (implemented later).
+
+use super::{Greediness, Matcher, Path, Pattern};
+use crate::{EdgeType, Envelope};
+use bc_components::DigestProvider;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Axis {
+    Subject,
+    Assertion,
+    Predicate,
+    Object,
+    Wrapped,
+}
+
+impl Axis {
+    /// Return `(child, EdgeType)` pairs reachable from `env` via this axis.
+    pub fn children(&self, env: &Envelope) -> Vec<(Envelope, EdgeType)> {
+        use bc_envelope::base::envelope::EnvelopeCase::*;
+        // println!("Axis::children called with axis: {:?}", self);
+        // println!("Case: {:?}", env.case());
+        // println!("Envelope: {}", env.format_flat());
+        match (self, env.case()) {
+            (Axis::Subject, Node { subject, .. }) => {
+                vec![(subject.clone(), EdgeType::Subject)]
+            }
+            (Axis::Assertion, Node { assertions, .. }) => assertions
+                .iter()
+                .cloned()
+                .map(|a| (a, EdgeType::Assertion))
+                .collect(),
+            (Axis::Predicate, Assertion(a)) => {
+                vec![(a.predicate().clone(), EdgeType::Predicate)]
+            }
+            (Axis::Object, Assertion(a)) => {
+                vec![(a.object().clone(), EdgeType::Object)]
+            }
+            (Axis::Wrapped, Node { subject, .. }) => {
+                if subject.is_wrapped() {
+                    vec![(
+                        subject.unwrap_envelope().unwrap(),
+                        EdgeType::Wrapped,
+                    )]
+                } else {
+                    vec![]
+                }
+            }
+            (Axis::Wrapped, Wrapped { envelope, .. }) => {
+                vec![(envelope.clone(), EdgeType::Wrapped)]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Bytecode instructions for the pattern VM.
+#[derive(Debug, Clone)]
+pub enum Instr {
+    /// Match predicate: `literals[idx].matches(env)`
+    MatchPredicate(usize),
+    /// Match structure: use `literals[idx].paths(env)` for structure patterns
+    MatchStructure(usize),
+    /// ε-split: fork execution to `a` and `b`
+    Split { a: usize, b: usize },
+    /// Unconditional jump to instruction at index
+    Jump(usize),
+    /// Descend to children via axis, one thread per child
+    PushAxis(Axis),
+    /// Pop one envelope from the path
+    Pop,
+    /// Emit current path
+    Save,
+    /// Final accept, emit current path and halt thread
+    Accept,
+    /// Recursively search for pattern at `pat_idx`
+    Search { pat_idx: usize },
+    /// Save current path and start new sequence from last envelope
+    ExtendSequence,
+    /// Combine saved path with current path for final result
+    CombineSequence,
+    /// Navigate to subject of current envelope
+    NavigateSubject,
+    /// Match only if pattern at `pat_idx` does not match
+    NotMatch { pat_idx: usize },
+    /// Repeat a sub pattern according to range and greediness
+    Repeat {
+        pat_idx: usize,
+        min: usize,
+        max: Option<usize>,
+        mode: Greediness,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct Program {
+    pub code: Vec<Instr>,
+    pub literals: Vec<Pattern>,
+}
+
+/// Internal back-tracking state.
+#[derive(Clone)]
+struct Thread {
+    pc: usize,
+    env: Envelope,
+    path: Path,
+    /// Stack of saved paths for nested sequence patterns
+    saved_paths: Vec<Path>,
+}
+
+/// Match atomic patterns without recursion into the VM.
+///
+/// This function handles only the patterns that are safe to use in
+/// MatchPredicate instructions - Leaf, Structure, Any, and None patterns. Meta
+/// patterns should never be passed to this function as they need to be compiled
+/// to bytecode.
+///
+/// For SearchPattern, we provide a temporary fallback that uses the old
+/// recursive implementation until proper bytecode compilation is implemented.
+#[allow(clippy::panic)]
+pub(crate) fn atomic_paths(
+    p: &crate::pattern::Pattern,
+    env: &Envelope,
+) -> Vec<Path> {
+    use crate::pattern::Pattern::*;
+    match p {
+        Leaf(l) => l.paths(env),
+        Structure(s) => s.paths(env),
+        Meta(meta) => match meta {
+            crate::pattern::meta::MetaPattern::Any(a) => a.paths(env),
+            crate::pattern::meta::MetaPattern::None(n) => n.paths(env),
+            crate::pattern::meta::MetaPattern::Search(_) => {
+                panic!(
+                    "SearchPattern should be compiled to Search instruction, not MatchPredicate"
+                );
+            }
+            _ => panic!(
+                "non-atomic meta pattern used in MatchPredicate: {:?}",
+                meta
+            ),
+        },
+    }
+}
+
+fn repeat_paths(
+    pat: &Pattern,
+    env: &Envelope,
+    path: &Path,
+    min: usize,
+    max: Option<usize>,
+    mode: Greediness,
+) -> Vec<(Envelope, Path)> {
+    let mut states: Vec<Vec<(Envelope, Path)>> = vec![vec![(env.clone(), path.clone())]];
+    let bound = max.unwrap_or(usize::MAX);
+    for _ in 0..bound {
+        let mut next = Vec::new();
+        for (e, pth) in states.last().unwrap().iter() {
+            for sub_path in pat.paths(e) {
+                if let Some(last) = sub_path.last() {
+                    if last.digest() == e.digest() {
+                        continue;
+                    }
+                    let mut combined = pth.clone();
+                    if sub_path.first() == Some(e) {
+                        combined.extend(sub_path.iter().skip(1).cloned());
+                    } else {
+                        combined.extend(sub_path.iter().cloned());
+                    }
+                    next.push((last.clone(), combined));
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        states.push(next);
+    }
+
+    let max_possible = states.len() - 1;
+    let max_allowed = bound.min(max_possible);
+    if max_allowed < min {
+        return Vec::new();
+    }
+
+    let counts: Vec<usize> = match mode {
+        Greediness::Greedy => (min..=max_allowed).rev().collect(),
+        Greediness::Lazy => (min..=max_allowed).collect(),
+        Greediness::Possessive => vec![max_allowed],
+    };
+
+    let mut out = Vec::new();
+    for c in counts {
+        if let Some(list) = states.get(c) {
+            out.extend(list.clone());
+        }
+    }
+    out
+}
+
+/// Execute `prog` starting at `root`.  Every time `SAVE` or `ACCEPT` executes,
+/// current `path` is pushed into result.
+/// Execute a single thread until it halts. Returns true if any paths were
+/// produced.
+fn run_thread(prog: &Program, start: Thread, out: &mut Vec<Path>) -> bool {
+    use Instr::*;
+    let mut produced = false;
+    let mut stack = vec![start];
+
+    while let Some(mut th) = stack.pop() {
+        loop {
+            match prog.code[th.pc] {
+                MatchPredicate(idx) => {
+                    if atomic_paths(&prog.literals[idx], &th.env).is_empty() {
+                        break;
+                    }
+                    th.pc += 1;
+                }
+                MatchStructure(idx) => {
+                    // Use the structure pattern's direct matcher, not the
+                    // compiled pattern
+                    let structure_paths =
+                        if let crate::pattern::Pattern::Structure(sp) =
+                            &prog.literals[idx]
+                        {
+                            // Call the structure pattern's direct paths method
+                            sp.paths(&th.env)
+                        } else {
+                            panic!(
+                                "MatchStructure used with non-structure pattern"
+                            );
+                        };
+
+                    if structure_paths.is_empty() {
+                        break;
+                    }
+
+                    th.pc += 1; // Advance to next instruction
+
+                    // Spawn a new thread for each path found by the structure
+                    // pattern
+                    for (i, structure_path) in
+                        structure_paths.into_iter().enumerate()
+                    {
+                        if i == 0 {
+                            // Use the first path for the current thread
+                            th.path = structure_path.clone();
+                            if let Some(last_env) = structure_path.last() {
+                                th.env = last_env.clone();
+                            }
+                        } else {
+                            // Spawn new threads for the remaining paths
+                            let mut fork = th.clone();
+                            fork.path = structure_path.clone();
+                            if let Some(last_env) = structure_path.last() {
+                                fork.env = last_env.clone();
+                            }
+                            stack.push(fork);
+                        }
+                    }
+                }
+                Split { a, b } => {
+                    let mut fork = th.clone();
+                    fork.pc = a;
+                    stack.push(fork);
+                    th.pc = b;
+                }
+                Jump(t) => th.pc = t,
+                PushAxis(axis) => {
+                    th.pc += 1;
+                    for (child, _edge) in axis.children(&th.env) {
+                        let mut fork = th.clone();
+                        fork.env = child.clone();
+                        fork.path.push(child);
+                        stack.push(fork);
+                    }
+                    break; // parent path stops here
+                }
+                Pop => {
+                    th.path.pop();
+                    th.pc += 1;
+                }
+                Save => {
+                    out.push(th.path.clone());
+                    produced = true;
+                    th.pc += 1;
+                }
+                Accept => {
+                    out.push(th.path.clone());
+                    produced = true;
+                    break;
+                }
+                Search { pat_idx } => {
+                    // old SearchPattern::paths logic, but in-place and
+                    // non-recursive
+                    let inner = &prog.literals[pat_idx];
+
+                    // 1) check current node and get the actual paths it matches
+                    let found_paths = match inner {
+                        crate::pattern::Pattern::Leaf(_) => {
+                            inner.paths(&th.env)
+                        }
+                        crate::pattern::Pattern::Structure(_) => {
+                            inner.paths(&th.env)
+                        }
+                        crate::pattern::Pattern::Meta(_) => {
+                            inner.paths(&th.env)
+                        }
+                    };
+
+                    // If we found any paths, emit them by extending the current
+                    // path
+                    if !found_paths.is_empty() {
+                        produced = true;
+                        for found_path in found_paths {
+                            // Special case: if the found path is just the
+                            // current envelope,
+                            // emit the current path instead of extending it
+                            if found_path.len() == 1 && found_path[0] == th.env
+                            {
+                                out.push(th.path.clone());
+                            } else {
+                                // Extend current path with the found path
+                                let mut result_path = th.path.clone();
+                                result_path.extend(found_path);
+                                out.push(result_path);
+                            }
+                        }
+                    }
+
+                    // 2) always walk children (same traversal as
+                    //    Envelope::walk)
+                    // Collect all children first, then push in reverse order to
+                    // maintain the same traversal order as
+                    // the original recursive implementation
+                    // Build child list following the same structure order as
+                    // `Envelope::walk_structure`. This ensures every envelope
+                    // is visited exactly once.
+                    let mut all_children = Vec::new();
+                    use bc_envelope::base::envelope::EnvelopeCase::*;
+                    match th.env.case() {
+                        Node { subject, assertions, .. } => {
+                            all_children.push(subject.clone());
+                            for assertion in assertions {
+                                all_children.push(assertion.clone());
+                            }
+                        }
+                        Wrapped { envelope, .. } => {
+                            all_children.push(envelope.clone());
+                        }
+                        Assertion(assertion) => {
+                            all_children.push(assertion.predicate().clone());
+                            all_children.push(assertion.object().clone());
+                        }
+                        _ => {}
+                    }
+
+                    // Push child threads in reverse order so stack processes
+                    // them in forward order
+                    for child in all_children.into_iter().rev() {
+                        let mut fork = th.clone();
+                        fork.env = child.clone();
+                        fork.path.push(child);
+                        // fork continues with same PC to re-execute Search at
+                        // child
+                        stack.push(fork);
+                    }
+
+                    // This thread is done - either it emitted results or it
+                    // didn't
+                    break;
+                }
+                ExtendSequence => {
+                    // Save the current path and switch to the last envelope for
+                    // the rest of the sequence
+                    if let Some(last_env) = th.path.last().cloned() {
+                        th.saved_paths.push(th.path.clone());
+                        th.env = last_env.clone();
+                        th.path = vec![last_env]; // Start fresh path from the last envelope
+                    }
+                    th.pc += 1;
+                }
+                CombineSequence => {
+                    // Combine saved path with current path, extending the saved
+                    // path
+                    if let Some(saved_path) = th.saved_paths.pop() {
+                        let mut combined = saved_path.clone();
+
+                        // If the current path starts with the same envelope as
+                        // the saved path ends with,
+                        // skip the first element to avoid duplication.
+                        // Otherwise, append the whole current path.
+                        if let (Some(saved_last), Some(current_first)) =
+                            (saved_path.last(), th.path.first())
+                        {
+                            if saved_last == current_first {
+                                // Skip first element to avoid duplication
+                                combined
+                                    .extend(th.path.iter().skip(1).cloned());
+                            } else {
+                                // Append whole current path
+                                combined.extend(th.path.iter().cloned());
+                            }
+                        } else {
+                            // Append whole current path if one of the paths is
+                            // empty
+                            combined.extend(th.path.iter().cloned());
+                        }
+
+                        th.path = combined;
+                    }
+                    th.pc += 1;
+                }
+                Repeat { pat_idx, min, max, mode } => {
+                    let pat = &prog.literals[pat_idx];
+                    let results = repeat_paths(pat, &th.env, &th.path, min, max, mode);
+                    if results.is_empty() {
+                        break;
+                    }
+                    // Try each repetition count in order. `run_thread` fully
+                    // explores all branches for that count and returns `true`
+                    // if it yields any paths. Once one count succeeds we stop
+                    // trying further counts, emulating regex greedy/lazy
+                    // semantics while still returning all matching paths for
+                    // the chosen count.
+                    let next_pc = th.pc + 1;
+                    let mut success = false;
+                    for (env_after, path_after) in results {
+                        let mut fork = th.clone();
+                        fork.pc = next_pc;
+                        fork.env = env_after;
+                        fork.path = path_after;
+                        if run_thread(prog, fork, out) {
+                            produced = true;
+                            success = true;
+                            break;
+                        }
+                    }
+                    if !success {
+                        // None of the repetition counts allowed the rest to match
+                    }
+                    break;
+                }
+                NavigateSubject => {
+                    // If the current envelope is a node, navigate to its
+                    // subject and update the path.
+                    if th.env.is_node() {
+                        let subject = th.env.subject();
+                        th.env = subject.clone();
+                        th.path.push(subject);
+                    }
+                    th.pc += 1;
+                }
+                NotMatch { pat_idx } => {
+                    // Check if the pattern matches. If it doesn't match, the
+                    // NOT pattern succeeds. If it does
+                    // match, the NOT pattern fails and we kill this thread.
+
+                    // For atomic patterns, use atomic_paths for efficiency
+                    let pattern = &prog.literals[pat_idx];
+                    let pattern_matches = match pattern {
+                        crate::pattern::Pattern::Leaf(_) => {
+                            pattern.matches(&th.env)
+                        }
+                        crate::pattern::Pattern::Structure(_) => {
+                            pattern.matches(&th.env)
+                        }
+                        crate::pattern::Pattern::Meta(_) => {
+                            pattern.matches(&th.env)
+                        }
+                    };
+
+                    if pattern_matches {
+                        // Inner pattern matches, so NOT pattern fails - kill
+                        // this thread
+                        break;
+                    } else {
+                        // Inner pattern doesn't match, so NOT pattern succeeds
+                        // - continue
+                        th.pc += 1;
+                    }
+                }
+            }
+        }
+    }
+    produced
+}
+
+/// Execute `prog` starting at `root`.  Every time `SAVE` or `ACCEPT` executes,
+/// the current `path` is pushed into the result.
+pub fn run(prog: &Program, root: &Envelope) -> Vec<Path> {
+    let mut out = Vec::new();
+    let start = Thread {
+        pc: 0,
+        env: root.clone(),
+        path: vec![root.clone()],
+        saved_paths: Vec::new(),
+    };
+    run_thread(prog, start, &mut out);
+    out
+}

--- a/bc-envelope-pattern/tests/common/check_encoding.rs
+++ b/bc-envelope-pattern/tests/common/check_encoding.rs
@@ -1,0 +1,37 @@
+use anyhow::{anyhow, bail};
+use bc_components::DigestProvider;
+use dcbor::prelude::*;
+
+use crate::Envelope;
+
+pub trait CheckEncoding {
+    #[allow(dead_code)]
+    fn check_encoding(&self) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+}
+
+impl CheckEncoding for Envelope {
+    /// Used by test suite to check round-trip encoding of `Envelope`.
+    fn check_encoding(&self) -> anyhow::Result<Self> {
+        let cbor = self.tagged_cbor();
+        let restored = Envelope::from_tagged_cbor(cbor.clone());
+        let restored = restored.map_err(|_| {
+            println!("=== EXPECTED");
+            println!("{}", self.format());
+            println!("=== GOT");
+            println!("{}", cbor.diagnostic());
+            println!("===");
+            anyhow!("Invalid format")
+        })?;
+        if self.digest() != restored.digest() {
+            println!("=== EXPECTED");
+            println!("{}", self.format());
+            println!("=== GOT");
+            println!("{}", restored.format());
+            println!("===");
+            bail!("Digest mismatch");
+        }
+        Ok(self.clone())
+    }
+}

--- a/bc-envelope-pattern/tests/common/mod.rs
+++ b/bc-envelope-pattern/tests/common/mod.rs
@@ -1,0 +1,32 @@
+pub mod check_encoding;
+pub mod pattern_utils;
+pub mod test_data;
+pub mod test_seed;
+
+/// A macro to assert that two values are equal, printing them if they are not,
+/// including newlines and indentation they may contain. This macro is useful
+/// for debugging tests where you want to see the actual and expected values
+/// when they do not match.
+#[macro_export]
+macro_rules! assert_actual_expected {
+    ($actual:expr, $expected:expr $(,)?) => {
+        match (&$actual, &$expected) {
+            (actual_val, expected_val) => {
+                if !(*actual_val == *expected_val) {
+                    println!("Actual:\n{actual_val}\nExpected:\n{expected_val}");
+                    assert_eq!(*actual_val, *expected_val);
+                }
+            }
+        }
+    };
+    ($actual:expr, $expected:expr, $($arg:tt)+) => {
+        match (&$actual, &$expected) {
+            (actual_val, expected_val) => {
+                if !(*actual_val == *expected_val) {
+                    println!("Actual:\n{actual_val}\nExpected:\n{expected_val}");
+                    assert_eq!(*actual_val, *expected_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                }
+            }
+        }
+    };
+}

--- a/bc-envelope-pattern/tests/common/pattern_utils.rs
+++ b/bc-envelope-pattern/tests/common/pattern_utils.rs
@@ -1,0 +1,23 @@
+#![allow(dead_code)]
+
+use bc_envelope::prelude::*;
+
+// Format each path element on its own line, each line successively indented by
+// 4 spaces.
+pub fn format_path(path: &Path) -> String {
+    let mut lines = Vec::new();
+    for (i, element) in path.iter().enumerate() {
+        let indent = " ".repeat(i * 4);
+        lines.push(format!(
+            "{}{} {}",
+            indent,
+            element.short_id(DigestDisplayFormat::Short),
+            element.format_flat()
+        ));
+    }
+    lines.join("\n")
+}
+
+pub fn format_paths(paths: &[Path]) -> String {
+    paths.iter().map(format_path).collect::<Vec<_>>().join("\n")
+}

--- a/bc-envelope-pattern/tests/common/test_data.rs
+++ b/bc-envelope-pattern/tests/common/test_data.rs
@@ -1,0 +1,181 @@
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+
+use bc_components::{
+    Nonce, PrivateKeyBase, PublicKeys, PublicKeysProvider, SymmetricKey,
+};
+use bc_envelope::prelude::*;
+use hex_literal::hex;
+
+pub const PLAINTEXT_HELLO: &str = "Hello.";
+
+pub fn hello_envelope() -> Envelope { Envelope::new(PLAINTEXT_HELLO) }
+#[cfg(feature = "known_value")]
+pub fn known_value_envelope() -> Envelope { Envelope::new(known_values::NOTE) }
+pub fn assertion_envelope() -> Envelope {
+    Envelope::new_assertion("knows", "Bob")
+}
+
+pub fn single_assertion_envelope() -> Envelope {
+    Envelope::new("Alice").add_assertion("knows", "Bob")
+}
+
+pub fn double_assertion_envelope() -> Envelope {
+    single_assertion_envelope().add_assertion("knows", "Carol")
+}
+
+pub fn wrapped_envelope() -> Envelope { hello_envelope().wrap_envelope() }
+pub fn double_wrapped_envelope() -> Envelope {
+    wrapped_envelope().wrap_envelope()
+}
+
+pub fn alice_seed() -> Vec<u8> {
+    hex!("82f32c855d3d542256180810797e0073").into()
+}
+pub fn alice_private_key() -> PrivateKeyBase {
+    PrivateKeyBase::from_data(alice_seed())
+}
+pub fn alice_public_key() -> PublicKeys { alice_private_key().public_keys() }
+
+// pub fn bob_identifier() -> ARID {
+// ARID::from_data(hex!("
+// d44c5e0afd353f47b02f58a5a3a29d9a2efa6298692f896cd2923268599a0d0f")) }
+pub fn bob_seed() -> Vec<u8> { hex!("187a5973c64d359c836eba466a44db7b").into() }
+pub fn bob_private_key() -> PrivateKeyBase {
+    PrivateKeyBase::from_data(bob_seed())
+}
+pub fn bob_public_key() -> PublicKeys { bob_private_key().public_keys() }
+
+// pub fn carol_identifier() -> ARID {
+// ARID::from_data(hex!("
+// 06c777262faedf49a443277474c1c08531efcff4c58e9cb3b04f7fc1c0e6d60d")) }
+pub fn carol_seed() -> Vec<u8> {
+    hex!("8574afab18e229651c1be8f76ffee523").into()
+}
+pub fn carol_private_key() -> PrivateKeyBase {
+    PrivateKeyBase::from_data(carol_seed())
+}
+pub fn carol_public_key() -> PublicKeys { carol_private_key().public_keys() }
+
+// pub fn example_ledger_identifier() -> ARID {
+// ARID::from_data(hex!("
+// 0eda5ce79a2b5619e387f490861a2e7211559029b3b369cf98fb749bd3ba9a5d")) }
+// pub fn example_ledger_seed() -> Vec<u8> {
+// hex!("d6737ab34e4e8bb05b6ac035f9fba81a").into() }
+// pub fn example_ledger_private_key() -> PrivateKeyBase {
+// PrivateKeyBase::from_data(&example_ledger_seed()) }
+// pub fn example_ledger_public_key() -> PublicKeys {
+// example_ledger_private_key().public_key() }
+
+// pub fn state_identifier() -> ARID {
+// ARID::from_data(hex!("
+// 04363d5ff99733bc0f1577baba440af1cf344ad9e454fad9d128c00fef6505e8")) }
+// pub fn state_seed() -> Vec<u8> {
+// hex!("3e9271f46cdb85a3b584e7220b976918").into() } pub fn state_private_key()
+// -> PrivateKeyBase { PrivateKeyBase::from_data(&state_seed()) }
+// pub fn state_public_key() -> PublicKeys { state_private_key().public_key() }
+
+pub fn fake_content_key() -> SymmetricKey {
+    SymmetricKey::from_data(hex!(
+        "526afd95b2229c5381baec4a1788507a3c4a566ca5cce64543b46ad12aff0035"
+    ))
+}
+pub fn fake_nonce() -> Nonce {
+    Nonce::from_data(hex!("4d785658f36c22fb5aed3ac0"))
+}
+
+#[cfg(feature = "signature")]
+pub fn credential() -> Envelope {
+    use std::{cell::RefCell, rc::Rc};
+
+    use bc_components::ARID;
+    use bc_envelope::SigningOptions;
+    use bc_rand::make_fake_random_number_generator;
+
+    use crate::common::check_encoding::CheckEncoding;
+
+    let rng = Rc::new(RefCell::new(make_fake_random_number_generator()));
+    let options = SigningOptions::Schnorr { rng };
+    Envelope::new(ARID::from_data(hex!(
+        "4676635a6e6068c2ef3ffd8ff726dd401fd341036e920f136a1d8af5e829496d"
+    )))
+    .add_assertion(known_values::IS_A, "Certificate of Completion")
+    .add_assertion(known_values::ISSUER, "Example Electrical Engineering Board")
+    .add_assertion(
+        known_values::CONTROLLER,
+        "Example Electrical Engineering Board",
+    )
+    .add_assertion("firstName", "James")
+    .add_assertion("lastName", "Maxwell")
+    .add_assertion("issueDate", dcbor::Date::from_string("2020-01-01").unwrap())
+    .add_assertion(
+        "expirationDate",
+        dcbor::Date::from_string("2028-01-01").unwrap(),
+    )
+    .add_assertion("photo", "This is James Maxwell's photo.")
+    .add_assertion("certificateNumber", "123-456-789")
+    .add_assertion("subject", "RF and Microwave Engineering")
+    .add_assertion("continuingEducationUnits", 1)
+    .add_assertion("professionalDevelopmentHours", 15)
+    .add_assertion("topics", vec!["Subject 1", "Subject 2"].to_cbor())
+    .wrap_envelope()
+    .add_signature_opt(&alice_private_key(), Some(options), None)
+    .add_assertion(
+        known_values::NOTE,
+        "Signed by Example Electrical Engineering Board",
+    )
+    .check_encoding()
+    .unwrap()
+}
+
+pub fn redacted_credential() -> Envelope {
+    let credential = credential();
+    let mut target = HashSet::new();
+    target.insert(credential.digest().into_owned());
+    for assertion in credential.assertions() {
+        target.extend(assertion.deep_digests());
+    }
+    target.insert(credential.subject().digest().into_owned());
+    let content = credential.subject().unwrap_envelope().unwrap();
+    target.insert(content.digest().into_owned());
+    target.insert(content.subject().digest().into_owned());
+
+    target.extend(
+        content
+            .assertion_with_predicate("firstName")
+            .unwrap()
+            .shallow_digests(),
+    );
+    target.extend(
+        content
+            .assertion_with_predicate("lastName")
+            .unwrap()
+            .shallow_digests(),
+    );
+    target.extend(
+        content
+            .assertion_with_predicate(known_values::IS_A)
+            .unwrap()
+            .shallow_digests(),
+    );
+    target.extend(
+        content
+            .assertion_with_predicate(known_values::ISSUER)
+            .unwrap()
+            .shallow_digests(),
+    );
+    target.extend(
+        content
+            .assertion_with_predicate("subject")
+            .unwrap()
+            .shallow_digests(),
+    );
+    target.extend(
+        content
+            .assertion_with_predicate("expirationDate")
+            .unwrap()
+            .shallow_digests(),
+    );
+    credential.elide_revealing_set(&target)
+}

--- a/bc-envelope-pattern/tests/common/test_seed.rs
+++ b/bc-envelope-pattern/tests/common/test_seed.rs
@@ -1,0 +1,167 @@
+#![cfg(feature = "types")]
+
+use bc_components::tags;
+use bc_envelope::prelude::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Seed {
+    data: Vec<u8>,
+    name: String,
+    note: String,
+    creation_date: Option<dcbor::Date>,
+}
+
+impl Seed {
+    pub fn new<T>(data: T) -> Self
+    where
+        T: AsRef<[u8]>,
+    {
+        Self::new_opt(data, String::new(), String::new(), None)
+    }
+
+    pub fn new_opt<T, S, U>(
+        data: T,
+        name: S,
+        note: U,
+        creation_date: Option<dcbor::Date>,
+    ) -> Self
+    where
+        T: AsRef<[u8]>,
+        S: AsRef<str>,
+        U: AsRef<str>,
+    {
+        Self {
+            data: data.as_ref().to_vec(),
+            name: name.as_ref().to_string(),
+            note: note.as_ref().to_string(),
+            creation_date,
+        }
+    }
+
+    pub fn data(&self) -> &[u8] { &self.data }
+
+    pub fn name(&self) -> &str { &self.name }
+
+    pub fn set_name(&mut self, name: impl AsRef<str>) {
+        self.name = name.as_ref().to_string();
+    }
+
+    pub fn note(&self) -> &str { &self.note }
+
+    pub fn set_note(&mut self, note: impl AsRef<str>) {
+        self.note = note.as_ref().to_string();
+    }
+
+    pub fn creation_date(&self) -> Option<&dcbor::Date> {
+        self.creation_date.as_ref()
+    }
+
+    pub fn set_creation_date(
+        &mut self,
+        creation_date: Option<impl AsRef<dcbor::Date>>,
+    ) {
+        self.creation_date = creation_date.map(|s| s.as_ref().clone());
+    }
+}
+
+impl CBORTagged for Seed {
+    fn cbor_tags() -> Vec<Tag> { tags_for_values(&[tags::TAG_SEED]) }
+}
+
+impl From<Seed> for CBOR {
+    fn from(value: Seed) -> Self { value.tagged_cbor() }
+}
+
+impl CBORTaggedEncodable for Seed {
+    fn untagged_cbor(&self) -> CBOR {
+        let mut map = dcbor::Map::new();
+        map.insert(1, CBOR::to_byte_string(self.data()));
+        if let Some(creation_date) = self.creation_date() {
+            map.insert(2, creation_date.clone());
+        }
+        if !self.name().is_empty() {
+            map.insert(3, self.name());
+        }
+        if !self.note().is_empty() {
+            map.insert(4, self.note());
+        }
+        map.into()
+    }
+}
+
+impl TryFrom<CBOR> for Seed {
+    type Error = dcbor::Error;
+
+    fn try_from(cbor: CBOR) -> dcbor::Result<Self> {
+        Self::from_tagged_cbor(cbor)
+    }
+}
+
+impl CBORTaggedDecodable for Seed {
+    fn from_untagged_cbor(cbor: CBOR) -> dcbor::Result<Self> {
+        let map = cbor.try_into_map()?;
+        let data = map
+            .extract::<i32, CBOR>(1)?
+            .try_into_byte_string()?
+            .to_vec();
+        if data.is_empty() {
+            return Err("invalid seed data".into());
+        }
+        let creation_date = map.get::<i32, dcbor::Date>(2);
+        let name = map.get::<i32, String>(3).unwrap_or_default();
+        let note = map.get::<i32, String>(4).unwrap_or_default();
+        Ok(Self::new_opt(data, name, note, creation_date))
+    }
+}
+
+impl From<Seed> for Envelope {
+    fn from(seed: Seed) -> Self {
+        let mut e = Envelope::new(CBOR::to_byte_string(seed.data()))
+            .add_type(known_values::SEED_TYPE)
+            .add_optional_assertion(
+                known_values::DATE,
+                seed.creation_date().cloned(),
+            );
+
+        if !seed.name().is_empty() {
+            e = e.add_assertion(known_values::NAME, seed.name());
+        }
+
+        if !seed.note().is_empty() {
+            e = e.add_assertion(known_values::NOTE, seed.note());
+        }
+
+        e
+    }
+}
+
+impl TryFrom<Envelope> for Seed {
+    type Error = dcbor::Error;
+
+    fn try_from(envelope: Envelope) -> dcbor::Result<Self> {
+        envelope.check_type(&known_values::SEED_TYPE)?;
+        let data = envelope
+            .subject()
+            .try_leaf()?
+            .try_into_byte_string()?
+            .to_vec();
+        let name = envelope
+            .extract_optional_object_for_predicate::<String>(
+                known_values::NAME,
+            )?
+            .unwrap_or_default()
+            .to_string();
+        let note = envelope
+            .extract_optional_object_for_predicate::<String>(
+                known_values::NOTE,
+            )?
+            .unwrap_or_default()
+            .to_string();
+        let creation_date = envelope
+            .extract_optional_object_for_predicate::<dcbor::Date>(
+                known_values::DATE,
+            )?
+            .map(|s| s.as_ref().clone());
+        Ok(Self::new_opt(data, name, note, creation_date))
+    }
+}

--- a/bc-envelope-pattern/tests/pattern_tests.rs
+++ b/bc-envelope-pattern/tests/pattern_tests.rs
@@ -1,0 +1,151 @@
+mod common;
+
+use bc_envelope::prelude::*;
+use bc_envelope_pattern::{Matcher, Pattern};
+use indoc::indoc;
+
+use crate::common::{pattern_utils::*, test_data::*};
+
+#[test]
+fn test_mixed_patterns_with_search() {
+    // Create a complex envelope structure
+    let envelope = Envelope::new("Alice")
+        .add_assertion("knows", "Bob")
+        .add_assertion("age", 30)
+        .add_assertion("secret", Envelope::new("top secret").elide());
+
+    // Search for any node patterns
+    let node_paths = Pattern::search(Pattern::any_node()).paths(&envelope);
+    assert_eq!(node_paths.len(), 1);
+
+    // Search for any obscured patterns
+    let obscured_paths = Pattern::search(Pattern::obscured()).paths(&envelope);
+    assert_eq!(obscured_paths.len(), 1);
+
+    // The obscured element should be the elided "top secret"
+    let obscured_element = obscured_paths[0].last().unwrap();
+    assert!(obscured_element.is_elided());
+
+    // Search for specific digest prefix
+    let alice_subject = envelope.subject();
+    let alice_digest = alice_subject.digest();
+    let alice_hex = hex::encode(alice_digest.as_bytes());
+    let alice_prefix = &alice_hex[0..8];
+
+    let digest_paths =
+        Pattern::search(Pattern::digest_hex_prefix(alice_prefix))
+            .paths(&envelope);
+    assert_eq!(digest_paths.len(), 1);
+
+    // The found element should be Alice
+    let alice_element = digest_paths[0].last().unwrap();
+    assert_eq!(alice_element.extract_subject::<String>().unwrap(), "Alice");
+}
+
+#[test]
+fn test_node_pattern_with_sequence() {
+    // Create envelope with exactly 2 assertions
+    let envelope = Envelope::new("Person")
+        .add_assertion("name", "Alice")
+        .add_assertion("age", 25);
+
+    // Test sequence matching node with 2 assertions then extracting subject
+    let paths = Pattern::sequence(vec![
+        Pattern::node_with_assertions_count(2),
+        Pattern::subject(),
+    ])
+    .paths(&envelope);
+
+    #[rustfmt::skip]
+    let expected = format!(
+        "{} \"Person\" [ \"age\": 25, \"name\": \"Alice\" ]\n    {} \"Person\"",
+        envelope.short_id(DigestDisplayFormat::Short),
+        envelope.subject().short_id(DigestDisplayFormat::Short)
+    );
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_redacted_credential_patterns() {
+    let redacted_credential = redacted_credential();
+    // println!("{}", redacted_credential.format());
+    let expected = indoc! {r#"
+        {
+            ARID(4676635a) [
+                'isA': "Certificate of Completion"
+                "expirationDate": 2028-01-01
+                "firstName": "James"
+                "lastName": "Maxwell"
+                "subject": "RF and Microwave Engineering"
+                'issuer': "Example Electrical Engineering Board"
+                ELIDED (7)
+            ]
+        } [
+            'note': "Signed by Example Electrical Engineering Board"
+            'signed': Signature
+        ]
+    "#}
+    .trim();
+    assert_actual_expected!(redacted_credential.format(), expected);
+
+    // Search for the obscured paths
+    let paths =
+        Pattern::search(Pattern::obscured()).paths(&redacted_credential);
+    // println!("{}", &format_paths(&paths));
+    assert_eq!(paths.len(), 7);
+
+    // Get the last elements of each path to check the obscured elements
+    let obscured_elements: Vec<_> = paths
+        .iter()
+        .map(|path| path.last().unwrap().clone())
+        .collect();
+
+    // Print them formatted as paths
+    let formatted_obscured: Vec<_> = obscured_elements
+        .iter()
+        .map(|el| vec![el.clone()])
+        .collect();
+    // println!("{}", format_paths(&formatted_obscured));
+    let expected = indoc! {r#"
+        1f9ff098 ELIDED
+        4a9b2e4d ELIDED
+        5171cbaf ELIDED
+        54b3e1e7 ELIDED
+        68895d8e ELIDED
+        8ec5e912 ELIDED
+        9b3d4785 ELIDED
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&formatted_obscured), expected);
+
+    // Get the un-redacted credential
+    let credential = credential();
+
+    // Get the digest of the first obscured element
+    let first_obscured_digest =
+        obscured_elements.first().unwrap().digest().into_owned();
+
+    // Find the digest of the first obscured element in the un-redacted
+    // credential
+    let found_paths =
+        Pattern::search(Pattern::digest(first_obscured_digest.clone()))
+            .paths(&credential);
+    // println!("{}", format_paths(&found_paths));
+    assert_eq!(found_paths.len(), 1);
+
+    // Get the last element of the found path
+    let found_element = found_paths[0].last().unwrap();
+    // println!("{}", found_element.format());
+    let expected = indoc! {r#"
+        "certificateNumber": "123-456-789"
+    "#}
+    .trim();
+    assert_actual_expected!(found_element.format(), expected);
+
+    // The digest of the found element should match the first obscured element
+    assert_eq!(
+        found_element.digest().into_owned(),
+        first_obscured_digest,
+        "The found element's digest should match the first obscured element's digest"
+    );
+}

--- a/bc-envelope-pattern/tests/pattern_tests_leaf.rs
+++ b/bc-envelope-pattern/tests/pattern_tests_leaf.rs
@@ -1,0 +1,786 @@
+mod common;
+
+use bc_envelope::prelude::*;
+use bc_envelope_pattern::{Matcher, Pattern};
+use indoc::indoc;
+
+use crate::common::pattern_utils::*;
+
+#[test]
+fn test_bool_pattern() {
+    // Does not match non-boolean subjects.
+    let envelope = Envelope::new(42);
+    assert!(!Pattern::any_bool().matches(&envelope));
+    assert!(!Pattern::bool(true).matches(&envelope));
+    assert!(!Pattern::bool(false).matches(&envelope));
+
+    // Matches a bare subject that is a boolean.
+    let envelope = Envelope::new(true);
+    assert!(Pattern::any_bool().matches(&envelope));
+    assert!(Pattern::bool(true).matches(&envelope));
+    assert!(!Pattern::bool(false).matches(&envelope));
+
+    // Matches a subject that is a boolean with an assertion.
+    let envelope = envelope.add_assertion("an", "assertion");
+    assert!(Pattern::any_bool().matches(&envelope));
+    assert!(Pattern::bool(true).matches(&envelope));
+    assert!(!Pattern::bool(false).matches(&envelope));
+
+    // The matched paths include the assertion. In other words, the
+    // path just includes the envelope itself as its only element.
+    let paths = Pattern::any_bool().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        50d1019e true [ "an": "assertion" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Matching a boolean and the subject in a sequence returns a path
+    // where the first element is the original envelope and the second
+    // element is the subject.
+    let paths =
+        Pattern::sequence(vec![Pattern::any_bool(), Pattern::subject()])
+            .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        50d1019e true [ "an": "assertion" ]
+            27abdedd true
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_number_pattern() {
+    // Does not match non-number subjects.
+    let envelope = Envelope::new("string");
+    assert!(!Pattern::any_number().matches(&envelope));
+    assert!(!Pattern::number(42).matches(&envelope));
+
+    // Matches a bare subject that is a number.
+    let envelope = Envelope::new(42);
+    assert!(Pattern::any_number().matches(&envelope));
+    assert!(Pattern::number(42).matches(&envelope));
+    assert!(!Pattern::number(43).matches(&envelope));
+    assert!(Pattern::number_range(40..=50).matches(&envelope));
+    assert!(!Pattern::number_range(43..=50).matches(&envelope));
+    assert!(Pattern::number_greater_than(41).matches(&envelope));
+    assert!(!Pattern::number_greater_than(42).matches(&envelope));
+    assert!(Pattern::number_less_than(43).matches(&envelope));
+    assert!(!Pattern::number_less_than(42).matches(&envelope));
+    assert!(Pattern::number_greater_than_or_equal(42).matches(&envelope));
+    assert!(!Pattern::number_greater_than_or_equal(43).matches(&envelope));
+
+    // Matches a subject that is a number with an assertion.
+    let envelope = envelope.add_assertion("an", "assertion");
+    assert!(Pattern::any_number().matches(&envelope));
+    assert!(Pattern::number(42).matches(&envelope));
+
+    // The matched paths include the assertion.
+    let paths = Pattern::any_number().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        6cb2ea4a 42 [ "an": "assertion" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Matching a number and the subject in a sequence returns a path
+    // where the first element is the original envelope and the second
+    // element is the subject.
+    let paths =
+        Pattern::sequence(vec![Pattern::any_number(), Pattern::subject()])
+            .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        6cb2ea4a 42 [ "an": "assertion" ]
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_text_pattern() {
+    // Does not match non-text subjects.
+    let envelope = Envelope::new(42);
+    assert!(!Pattern::any_text().matches(&envelope));
+    assert!(!Pattern::text("hello").matches(&envelope));
+
+    // Matches a bare subject that is text.
+    let envelope = Envelope::new("hello");
+    assert!(Pattern::any_text().matches(&envelope));
+    assert!(Pattern::text("hello").matches(&envelope));
+    assert!(!Pattern::text("world").matches(&envelope));
+    let regex = regex::Regex::new(r"^h.*o$").unwrap();
+    assert!(Pattern::text_regex(regex.clone()).matches(&envelope));
+
+    // Matches a subject that is text with an assertion.
+    let envelope = envelope.add_assertion("greeting", "world");
+    assert!(Pattern::any_text().matches(&envelope));
+    assert!(Pattern::text("hello").matches(&envelope));
+    assert!(!Pattern::text("world").matches(&envelope));
+    assert!(Pattern::text_regex(regex).matches(&envelope));
+
+    // The matched paths include the assertion.
+    let paths = Pattern::any_text().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        80a8c700 "hello" [ "greeting": "world" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Matching a text and the subject in a sequence returns a path
+    // where the first element is the original envelope and the second
+    // element is the subject.
+    let paths =
+        Pattern::sequence(vec![Pattern::any_text(), Pattern::subject()])
+            .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        80a8c700 "hello" [ "greeting": "world" ]
+            cb835593 "hello"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_date_pattern() {
+    use dcbor::Date;
+
+    // Does not match non-date subjects.
+    let envelope = Envelope::new("2023-12-25");
+    assert!(!Pattern::any_date().matches(&envelope));
+
+    // Create a date envelope
+    let date = Date::from_ymd(2023, 12, 25);
+    let envelope = Envelope::new(date.clone());
+
+    // Matches a bare subject that is a date.
+    assert!(Pattern::any_date().matches(&envelope));
+    assert!(Pattern::date(date.clone()).matches(&envelope));
+    assert!(!Pattern::date(Date::from_ymd(2023, 12, 24)).matches(&envelope));
+
+    // Test date range matching
+    let start = Date::from_ymd(2023, 12, 20);
+    let end = Date::from_ymd(2023, 12, 30);
+    assert!(Pattern::date_range(start..=end).matches(&envelope));
+
+    let start = Date::from_ymd(2023, 12, 26);
+    let end = Date::from_ymd(2023, 12, 30);
+    assert!(!Pattern::date_range(start..=end).matches(&envelope));
+
+    // Test ISO-8601 string matching
+    assert!(Pattern::date_iso8601("2023-12-25").matches(&envelope));
+    assert!(!Pattern::date_iso8601("2023-12-24").matches(&envelope));
+
+    // Test regex matching
+    let regex = regex::Regex::new(r"^2023-.*").unwrap();
+    assert!(Pattern::date_regex(regex).matches(&envelope));
+
+    let regex = regex::Regex::new(r"^2024-.*").unwrap();
+    assert!(!Pattern::date_regex(regex).matches(&envelope));
+
+    // Matches a subject that is a date with an assertion.
+    let envelope = envelope.add_assertion("type", "christmas");
+    assert!(Pattern::any_date().matches(&envelope));
+    assert!(Pattern::date(date.clone()).matches(&envelope));
+
+    // The matched paths include the assertion.
+    let paths = Pattern::any_date().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        20f45d77 2023-12-25 [ "type": "christmas" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Matching a date and the subject in a sequence returns a path
+    // where the first element is the original envelope and the second
+    // element is the subject.
+    let paths =
+        Pattern::sequence(vec![Pattern::any_date(), Pattern::subject()])
+            .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        20f45d77 2023-12-25 [ "type": "christmas" ]
+            3854ff69 2023-12-25
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Test with date-time (not just date)
+    let date_with_time = Date::from_ymd_hms(2023, 12, 25, 15, 30, 45);
+    let envelope_with_time = Envelope::new(date_with_time.clone());
+
+    assert!(Pattern::any_date().matches(&envelope_with_time));
+    assert!(
+        Pattern::date_iso8601("2023-12-25T15:30:45Z")
+            .matches(&envelope_with_time)
+    );
+
+    let regex = regex::Regex::new(r".*T15:30:45Z$").unwrap();
+    assert!(Pattern::date_regex(regex).matches(&envelope_with_time));
+}
+
+#[cfg(feature = "known_value")]
+#[test]
+fn test_known_value_pattern() {
+    use known_values;
+
+    // Does not match non-known-value subjects.
+    let envelope = Envelope::new("test");
+    assert!(!Pattern::any_known_value().matches(&envelope));
+    assert!(!Pattern::known_value(known_values::DATE).matches(&envelope));
+    assert!(!Pattern::known_value_named("date").matches(&envelope));
+
+    // Matches a bare subject that is a known value.
+    let envelope = Envelope::new(known_values::DATE);
+    assert!(Pattern::any_known_value().matches(&envelope));
+    assert!(Pattern::known_value(known_values::DATE).matches(&envelope));
+    assert!(Pattern::known_value_named("date").matches(&envelope));
+    assert!(!Pattern::known_value(known_values::LANGUAGE).matches(&envelope));
+    assert!(!Pattern::known_value_named("language").matches(&envelope));
+
+    // Matches a subject that is a known value with an assertion.
+    let envelope = envelope.add_assertion("meaning", "timestamp");
+    assert!(Pattern::any_known_value().matches(&envelope));
+    assert!(Pattern::known_value(known_values::DATE).matches(&envelope));
+    assert!(Pattern::known_value_named("date").matches(&envelope));
+    assert!(!Pattern::known_value(known_values::LANGUAGE).matches(&envelope));
+    assert!(!Pattern::known_value_named("language").matches(&envelope));
+
+    // The matched paths include the assertion. In other words, the
+    // path just includes the envelope itself as its only element.
+    let paths = Pattern::any_known_value().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        813f39cd 'date' [ "meaning": "timestamp" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Test matching by name
+    let paths = Pattern::known_value_named("date").paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        813f39cd 'date' [ "meaning": "timestamp" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Matching a known value and the subject in a sequence returns a path
+    // where the first element is the original envelope and the second
+    // element is the subject.
+    let paths =
+        Pattern::sequence(vec![Pattern::any_known_value(), Pattern::subject()])
+            .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        813f39cd 'date' [ "meaning": "timestamp" ]
+            2e40139b 'date'
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Test with unknown name should not match
+    assert!(!Pattern::known_value_named("unknown_name").matches(&envelope));
+}
+
+#[cfg(feature = "known_value")]
+#[test]
+fn test_known_value_regex_pattern() {
+    use regex::Regex;
+
+    let value = known_values::DATE;
+    let envelope =
+        Envelope::new(value.clone()).add_assertion("meaning", "timestamp");
+
+    // Test regex that matches "date" - Pattern should match
+    let regex = Regex::new(r"^da.*").unwrap();
+    assert!(Pattern::known_value_regex(regex).matches(&envelope));
+
+    // Test regex that matches names ending with "te" - Pattern should match
+    let regex = Regex::new(r".*te$").unwrap();
+    assert!(Pattern::known_value_regex(regex).matches(&envelope));
+
+    // Test case-insensitive regex - Pattern should match
+    let regex = Regex::new(r"(?i)^DATE$").unwrap();
+    assert!(Pattern::known_value_regex(regex).matches(&envelope));
+
+    // Test regex that doesn't match - Pattern should not match
+    let regex = Regex::new(r"^lang.*").unwrap();
+    assert!(!Pattern::known_value_regex(regex).matches(&envelope));
+
+    // Test with a different known value
+    let language_value = known_values::LANGUAGE;
+    let language_envelope = Envelope::new(language_value.clone());
+
+    // This regex should match "language"
+    let regex = Regex::new(r"lang.*").unwrap();
+    assert!(Pattern::known_value_regex(regex).matches(&language_envelope));
+
+    // This regex should not match "language"
+    let regex = Regex::new(r"^da.*").unwrap();
+    assert!(!Pattern::known_value_regex(regex).matches(&language_envelope));
+
+    // Test with non-known-value envelope - Pattern should not match
+    let text_envelope = Envelope::new("test");
+    let regex = Regex::new(r".*").unwrap();
+    assert!(!Pattern::known_value_regex(regex).matches(&text_envelope));
+
+    // Test regex pattern in sequence patterns
+    let regex = Regex::new(r".*te$").unwrap();
+    let paths = Pattern::sequence(vec![
+        Pattern::known_value_regex(regex),
+        Pattern::subject(),
+    ])
+    .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        813f39cd 'date' [ "meaning": "timestamp" ]
+            2e40139b 'date'
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_byte_string_pattern() {
+    use dcbor::prelude::*;
+
+    // Does not match non-byte-string subjects.
+    let envelope = Envelope::new("string");
+    assert!(!Pattern::any_byte_string().matches(&envelope));
+    assert!(!Pattern::byte_string(vec![1, 2, 3]).matches(&envelope));
+
+    // Test with a byte string "Hello"
+    let hello_bytes = vec![0x48, 0x65, 0x6c, 0x6c, 0x6f]; // "Hello"
+    let envelope = Envelope::new(CBOR::to_byte_string(hello_bytes.clone()));
+
+    // Matches any byte string
+    assert!(Pattern::any_byte_string().matches(&envelope));
+
+    // Matches exact byte string
+    assert!(Pattern::byte_string(hello_bytes.clone()).matches(&envelope));
+    assert!(!Pattern::byte_string(vec![1, 2, 3]).matches(&envelope));
+
+    // Matches binary regex
+    let regex = regex::bytes::Regex::new(r"^He.*o$").unwrap();
+    assert!(Pattern::byte_string_binary_regex(regex).matches(&envelope));
+
+    let non_matching_regex = regex::bytes::Regex::new(r"^World").unwrap();
+    assert!(
+        !Pattern::byte_string_binary_regex(non_matching_regex)
+            .matches(&envelope)
+    );
+
+    // Matches a subject that is a byte string with an assertion.
+    let envelope = envelope.add_assertion("type", "greeting");
+    assert!(Pattern::any_byte_string().matches(&envelope));
+    assert!(Pattern::byte_string(hello_bytes.clone()).matches(&envelope));
+
+    let regex = regex::bytes::Regex::new(r".*llo.*").unwrap();
+    assert!(Pattern::byte_string_binary_regex(regex).matches(&envelope));
+
+    // The matched paths include the assertion.
+    let paths = Pattern::any_byte_string().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        19c2bef3 Bytes(5) [ "type": "greeting" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Matching a byte string and the subject in a sequence returns a path
+    // where the first element is the original envelope and the second
+    // element is the subject.
+    let paths =
+        Pattern::sequence(vec![Pattern::any_byte_string(), Pattern::subject()])
+            .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        19c2bef3 Bytes(5) [ "type": "greeting" ]
+            3a91d2eb Bytes(5)
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Test with binary regex patterns
+    //
+    // IMPORTANT: Binary regex patterns must use the (?s-u) flags to work
+    // correctly with arbitrary bytes:
+    // - (?s) allows '.' to match newline characters (like 0x0a)
+    // - (?-u) disables unicode mode so '.' matches any byte, not just valid
+    //   UTF-8 sequences
+    //
+    // Example matching any byte string ending with h'0001020304':
+    // ```
+    // (?s-u).*\x00\x01\x02\x03\x04$
+    // ```
+
+    let binary_data = vec![0x00, 0x01, 0xFF, 0xAB, 0xCD];
+    let binary_envelope =
+        Envelope::new(CBOR::to_byte_string(binary_data.clone()));
+
+    // Test pattern that matches any byte containing 0xFF
+    let regex = regex::bytes::Regex::new(r"(?s-u).*\xFF.*").unwrap();
+    assert!(Pattern::byte_string_binary_regex(regex).matches(&binary_envelope));
+
+    // Test pattern that matches specific sequence
+    let regex = regex::bytes::Regex::new(r"(?s-u)\x00\x01").unwrap();
+    assert!(Pattern::byte_string_binary_regex(regex).matches(&binary_envelope));
+
+    // Test pattern that matches any 5 bytes (should match our binary data)
+    let regex = regex::bytes::Regex::new(r"(?s-u)^.{5}$").unwrap();
+    assert!(Pattern::byte_string_binary_regex(regex).matches(&binary_envelope));
+
+    // Test pattern that doesn't match (starts with 0xFF)
+    let regex = regex::bytes::Regex::new(r"(?s-u)^\xFF").unwrap();
+    assert!(
+        !Pattern::byte_string_binary_regex(regex).matches(&binary_envelope)
+    );
+
+    // Test pattern matching high bit bytes
+    let regex = regex::bytes::Regex::new(r"(?s-u)[\x80-\xFF]").unwrap();
+    assert!(Pattern::byte_string_binary_regex(regex).matches(&binary_envelope));
+}
+
+#[test]
+fn test_array_pattern() {
+    use dcbor::prelude::*;
+
+    // Does not match non-array subjects.
+    let envelope = Envelope::new("string");
+    assert!(!Pattern::any_array().matches(&envelope));
+    assert!(!Pattern::array_count(3).matches(&envelope));
+
+    // Test with a CBOR array
+    let array_data = vec![1, 2, 3].to_cbor();
+    let envelope = Envelope::new(array_data);
+
+    // Matches any array
+    assert!(Pattern::any_array().matches(&envelope));
+
+    // Matches exact count
+    assert!(Pattern::array_count(3).matches(&envelope));
+    assert!(!Pattern::array_count(5).matches(&envelope));
+
+    // Matches count range
+    assert!(Pattern::array_count_range(2..=4).matches(&envelope));
+    assert!(!Pattern::array_count_range(5..=10).matches(&envelope));
+
+    // Test with assertions
+    let envelope = envelope.add_assertion("type", "list");
+    assert!(Pattern::any_array().matches(&envelope));
+    assert!(Pattern::array_count(3).matches(&envelope));
+
+    // The matched paths include the assertion
+    let paths = Pattern::any_array().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        70db8c16 [1, 2, 3] [ "type": "list" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Test with empty array
+    let empty_array = Vec::<i32>::new().to_cbor();
+    let empty_envelope = Envelope::new(empty_array);
+    assert!(Pattern::any_array().matches(&empty_envelope));
+    assert!(Pattern::array_count(0).matches(&empty_envelope));
+    assert!(!Pattern::array_count(1).matches(&empty_envelope));
+
+    // Test sequence patterns
+    let paths =
+        Pattern::sequence(vec![Pattern::any_array(), Pattern::subject()])
+            .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        70db8c16 [1, 2, 3] [ "type": "list" ]
+            4abc3113 [1, 2, 3]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_map_pattern() {
+    use dcbor::prelude::*;
+
+    // Does not match non-map subjects.
+    let envelope = Envelope::new("string");
+    assert!(!Pattern::any_map().matches(&envelope));
+    assert!(!Pattern::map_count(2).matches(&envelope));
+
+    // Test with a CBOR map
+    let mut map = Map::new();
+    map.insert("key1", "value1");
+    map.insert("key2", "value2");
+    let envelope = Envelope::new(map);
+
+    // Matches any map
+    assert!(Pattern::any_map().matches(&envelope));
+
+    // Matches exact count
+    assert!(Pattern::map_count(2).matches(&envelope));
+    assert!(!Pattern::map_count(3).matches(&envelope));
+
+    // Matches count range
+    assert!(Pattern::map_count_range(1..=3).matches(&envelope));
+    assert!(!Pattern::map_count_range(5..=10).matches(&envelope));
+
+    // Test with assertions
+    let envelope = envelope.add_assertion("type", "dictionary");
+    assert!(Pattern::any_map().matches(&envelope));
+    assert!(Pattern::map_count(2).matches(&envelope));
+
+    // The matched paths include the assertion
+    let paths = Pattern::any_map().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        1d96ee45 {"key1": "value1", "key2": "value2"} [ "type": "dictionary" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Test with empty map
+    let empty_map = Map::new();
+    let empty_envelope = Envelope::new(empty_map);
+    assert!(Pattern::any_map().matches(&empty_envelope));
+    assert!(Pattern::map_count(0).matches(&empty_envelope));
+    assert!(!Pattern::map_count(1).matches(&empty_envelope));
+
+    // Test sequence patterns
+    let paths = Pattern::sequence(vec![Pattern::any_map(), Pattern::subject()])
+        .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        1d96ee45 {"key1": "value1", "key2": "value2"} [ "type": "dictionary" ]
+            0e16f9b4 {"key1": "value1", "key2": "value2"}
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_null_pattern() {
+    // Does not match non-null subjects.
+    let envelope = Envelope::new("string");
+    assert!(!Pattern::null().matches(&envelope));
+
+    // Matches a null subject.
+    let envelope = Envelope::null();
+    assert!(Pattern::null().matches(&envelope));
+
+    // Matches a subject that is null with an assertion.
+    let envelope = envelope.add_assertion("type", "null_value");
+    assert!(Pattern::null().matches(&envelope));
+
+    // The matched paths include the assertion.
+    let paths = Pattern::null().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        a72948d7 null [ "type": "null_value" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Matching a null and the subject in a sequence returns a path
+    // where the first element is the original envelope and the second
+    // element is the subject.
+    let paths = Pattern::sequence(vec![Pattern::null(), Pattern::subject()])
+        .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        a72948d7 null [ "type": "null_value" ]
+            b0b2988b null
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_tag_pattern() {
+    use dcbor::prelude::*;
+
+    // Does not match non-tagged subjects.
+    let envelope = Envelope::new("string");
+    assert!(!Pattern::any_tag().matches(&envelope));
+    assert!(!Pattern::tagged_with_value(100).matches(&envelope));
+
+    // Test with a tagged CBOR value
+    let tagged_cbor = CBOR::to_tagged_value(100, "tagged_content");
+    let envelope = Envelope::new(tagged_cbor);
+
+    // Matches any tag
+    assert!(Pattern::any_tag().matches(&envelope));
+
+    // Matches specific tag value
+    assert!(Pattern::tagged_with_value(100).matches(&envelope));
+    assert!(!Pattern::tagged_with_value(200).matches(&envelope));
+
+    // Matches specific tag object
+    let tag = Tag::with_value(100);
+    assert!(Pattern::tagged(tag).matches(&envelope));
+
+    let different_tag = Tag::with_value(200);
+    assert!(!Pattern::tagged(different_tag).matches(&envelope));
+
+    // Test with assertions
+    let envelope = envelope.add_assertion("format", "tagged");
+    assert!(Pattern::any_tag().matches(&envelope));
+    assert!(Pattern::tagged_with_value(100).matches(&envelope));
+
+    // The matched paths include the assertion
+    let paths = Pattern::any_tag().paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        b9457c8d 100("tagged_content") [ "format": "tagged" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Test sequence patterns
+    let paths = Pattern::sequence(vec![Pattern::any_tag(), Pattern::subject()])
+        .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        b9457c8d 100("tagged_content") [ "format": "tagged" ]
+            a8e58a0d 100("tagged_content")
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_tag_pattern_named() {
+    use dcbor::prelude::*;
+
+    // Ensure tags are registered for testing
+    bc_envelope::register_tags();
+
+    // Test with registered tag (date tag = 1)
+    let tagged_cbor = dcbor::Date::from_ymd(2023, 12, 25).to_cbor();
+    let envelope = Envelope::new(tagged_cbor);
+
+    // Should match by name
+    assert!(Pattern::tagged_with_name("date").matches(&envelope));
+
+    // Should not match with wrong name
+    assert!(!Pattern::tagged_with_name("unknown_tag").matches(&envelope));
+
+    // Test with unregistered tag
+    let unregistered_tagged_cbor =
+        CBOR::to_tagged_value(999, "unregistered_content");
+    let unregistered_envelope = Envelope::new(unregistered_tagged_cbor);
+
+    // Should not match by any name since tag 999 is not registered
+    assert!(!Pattern::tagged_with_name("date").matches(&unregistered_envelope));
+    assert!(
+        !Pattern::tagged_with_name("unknown_tag")
+            .matches(&unregistered_envelope)
+    );
+
+    // Test with non-tagged content
+    let text_envelope = Envelope::new("just text");
+    assert!(!Pattern::tagged_with_name("date").matches(&text_envelope));
+
+    // Test paths for matched envelope
+    let paths = Pattern::tagged_with_name("date").paths(&envelope);
+    // println!("{}", format_paths(&paths));
+    let expected = indoc! {r#"
+        3854ff69 2023-12-25
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+    assert_eq!(paths.len(), 1);
+    assert_eq!(paths[0].len(), 1);
+    assert_eq!(paths[0][0], envelope);
+
+    // Test in sequence pattern
+    let paths = Pattern::sequence(vec![
+        Pattern::tagged_with_name("date"),
+        Pattern::subject(),
+    ])
+    .paths(&envelope);
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_tag_pattern_regex() {
+    use dcbor::prelude::*;
+
+    // Ensure tags are registered for testing
+    bc_envelope::register_tags();
+
+    // Test with registered tag (date tag = 1)
+    let tagged_cbor = dcbor::Date::from_ymd(2023, 12, 25).to_cbor();
+    let envelope = Envelope::new(tagged_cbor);
+
+    // Regex that should match "date"
+    let regex = regex::Regex::new(r"^da.*").unwrap();
+    assert!(Pattern::tagged_with_regex(regex.clone()).matches(&envelope));
+
+    // Regex that should match names ending with "te"
+    let regex = regex::Regex::new(r".*te$").unwrap();
+    assert!(Pattern::tagged_with_regex(regex.clone()).matches(&envelope));
+
+    // Regex that should not match "date"
+    let regex = regex::Regex::new(r"^time.*").unwrap();
+    assert!(!Pattern::tagged_with_regex(regex.clone()).matches(&envelope));
+
+    // Test with unregistered tag
+    let unregistered_tagged_cbor =
+        CBOR::to_tagged_value(999, "unregistered_content");
+    let unregistered_envelope = Envelope::new(unregistered_tagged_cbor);
+
+    // Should not match any regex since tag 999 has no name in registry
+    let regex = regex::Regex::new(r".*").unwrap(); // Match everything
+    assert!(
+        !Pattern::tagged_with_regex(regex.clone())
+            .matches(&unregistered_envelope)
+    );
+
+    // Test with non-tagged content
+    let text_envelope = Envelope::new("just text");
+    let regex = regex::Regex::new(r".*").unwrap();
+    assert!(!Pattern::tagged_with_regex(regex.clone()).matches(&text_envelope));
+
+    // Test paths for matched envelope
+    let regex = regex::Regex::new(r"^da.*").unwrap();
+    let paths = Pattern::tagged_with_regex(regex).paths(&envelope);
+    assert_eq!(paths.len(), 1);
+    assert_eq!(paths[0].len(), 1);
+    assert_eq!(paths[0][0], envelope);
+
+    // Test in sequence pattern
+    let regex = regex::Regex::new(r".*te$").unwrap();
+    let paths = Pattern::sequence(vec![
+        Pattern::tagged_with_regex(regex),
+        Pattern::subject(),
+    ])
+    .paths(&envelope);
+    assert_eq!(paths.len(), 1);
+    assert_eq!(paths[0].len(), 1);
+    assert_eq!(paths[0][0], envelope);
+}
+
+#[test]
+fn test_tag_pattern_with_bc_components_tags() {
+    use dcbor::prelude::*;
+
+    // Ensure all tags are registered
+    bc_envelope::register_tags();
+
+    // Test with a bc-components tag (e.g., digest tag)
+    let digest_tag_value = 40001u64; // TAG_DIGEST from bc-tags
+    let tagged_cbor =
+        CBOR::to_tagged_value(digest_tag_value, [1u8, 2, 3, 4].as_slice());
+    let envelope = Envelope::new(tagged_cbor);
+
+    // Test tag name matching (assuming digest tag is registered with name
+    // "digest") This will verify if the tag is properly registered in the
+    // global registry
+    let pattern = Pattern::tagged_with_name("digest");
+    let matches = pattern.matches(&envelope);
+
+    // Also test regex matching for digest-related tags
+    let regex = regex::Regex::new(r".*digest.*").unwrap();
+    let pattern_regex = Pattern::tagged_with_regex(regex);
+    let matches_regex = pattern_regex.matches(&envelope);
+
+    // At minimum, the specific tag value should work
+    assert!(Pattern::tagged_with_value(digest_tag_value).matches(&envelope));
+    assert!(Pattern::any_tag().matches(&envelope));
+
+    // Print debug info for manual verification
+    println!(
+        "Digest tag {} matches by name: {}",
+        digest_tag_value, matches
+    );
+    println!(
+        "Digest tag {} matches by regex: {}",
+        digest_tag_value, matches_regex
+    );
+}

--- a/bc-envelope-pattern/tests/pattern_tests_meta.rs
+++ b/bc-envelope-pattern/tests/pattern_tests_meta.rs
@@ -1,0 +1,659 @@
+mod common;
+
+use bc_envelope::prelude::*;
+use bc_envelope_pattern::{Matcher, Pattern, Greediness};
+use indoc::indoc;
+
+use crate::common::pattern_utils::*;
+
+#[test]
+fn test_empty_sequence_pattern() {
+    let envelope = Envelope::new(42);
+
+    // An empty sequence pattern never matches.
+    let pattern = Pattern::sequence(vec![]);
+    let paths = pattern.paths(&envelope);
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn test_and_pattern() {
+    let envelope = Envelope::new(42).add_assertion("an", "assertion");
+
+    // A pattern that requires the envelope to match both a number and a text,
+    // which is impossible.
+    let impossible_pattern =
+        Pattern::and(vec![Pattern::number(42), Pattern::text("foo")]);
+    assert!(!impossible_pattern.matches(&envelope));
+
+    // A pattern that requires the envelope to match both a number greater
+    // than 40 and a number less than 50, which is possible.
+    let number_range_pattern = Pattern::and(vec![
+        Pattern::number_greater_than(40),
+        Pattern::number_less_than(50),
+    ]);
+    assert!(number_range_pattern.matches(&envelope));
+
+    // The path includes the assertion.
+    let paths = number_range_pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        6cb2ea4a 42 [ "an": "assertion" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // A sequence pattern that includes the number range pattern and then
+    // extracts the subject.
+    let number_range_with_subject_pattern =
+        Pattern::sequence(vec![number_range_pattern, Pattern::subject()]);
+    let paths = number_range_with_subject_pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        6cb2ea4a 42 [ "an": "assertion" ]
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_or_pattern() {
+    // A pattern that requires the envelope to match either the string "foo" or
+    // the string "bar".
+    let pattern = Pattern::or(vec![Pattern::text("bar"), Pattern::text("baz")]);
+
+    // An envelope that is a number, so it doesn't match the pattern.
+    let envelope = Envelope::new(42).add_assertion("an", "assertion");
+    assert!(!pattern.matches(&envelope));
+
+    // A pattern that requires the envelope to match either the string "foo" or
+    // a number greater than 40.
+    let foo_or_greater_than_40_pattern = Pattern::or(vec![
+        Pattern::text("foo"),
+        Pattern::number_greater_than(40),
+    ]);
+    // The subject doesn't match the first pattern but matches the second.
+    assert!(foo_or_greater_than_40_pattern.matches(&envelope));
+
+    // The match path includes the assertion.
+    let paths = foo_or_greater_than_40_pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        6cb2ea4a 42 [ "an": "assertion" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    let foo_or_greater_than_40_with_subject_pattern = Pattern::sequence(vec![
+        foo_or_greater_than_40_pattern,
+        Pattern::subject(),
+    ]);
+    let paths = foo_or_greater_than_40_with_subject_pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        6cb2ea4a 42 [ "an": "assertion" ]
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_one_element_sequence_pattern() {
+    // A pattern that matches a the number 42.
+    let number_pattern = Pattern::number(42);
+
+    let envelope = Envelope::new(42);
+    let expected = indoc! {r#"
+        7f83f7bd 42
+    "#}
+    .trim();
+    let paths = number_pattern.paths(&envelope);
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // A sequence of one pattern gives the same result as the single pattern.
+    let pattern = Pattern::sequence(vec![number_pattern]);
+    let paths = pattern.paths(&envelope);
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_wrapped_sequence() {
+    let env_1 = Envelope::new("data");
+    let wrapped_1 = env_1.wrap_envelope();
+    let wrapped_2 = wrapped_1.wrap_envelope();
+    let wrapped_3 = wrapped_2.wrap_envelope();
+    let wrapped_4 = wrapped_3.wrap_envelope();
+
+    // println!("{}", wrapped_4.tree_format());
+    let expected = indoc! {r#"
+        25cb582c WRAPPED
+            c1426a18 subj WRAPPED
+                ee8cade0 subj WRAPPED
+                    febc1555 subj WRAPPED
+                        e909da9a subj "data"
+    "#}
+    .trim();
+    assert_actual_expected!(wrapped_4.tree_format(), expected);
+
+    // println!("{}", wrapped_4.format_flat());
+    let expected = indoc! {r#"
+        { { { { "data" } } } }
+    "#}
+    .trim();
+    assert_actual_expected!(wrapped_4.format_flat(), expected);
+
+    // A pattern that matches a single wrapped envelope.
+    let wrapped_1_pattern = Pattern::sequence(vec![Pattern::wrapped()]);
+    let paths = wrapped_1_pattern.paths(&wrapped_4);
+    // println!("{}", format_paths(&paths));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        25cb582c { { { { "data" } } } }
+            c1426a18 { { { "data" } } }
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // A pattern that matches two wrapped envelopes in sequence.
+    let wrapped_2_pattern =
+        Pattern::sequence(vec![Pattern::wrapped(), Pattern::wrapped()]);
+    let paths = wrapped_2_pattern.paths(&wrapped_4);
+    // println!("{}", format_paths(&paths));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        25cb582c { { { { "data" } } } }
+            c1426a18 { { { "data" } } }
+                ee8cade0 { { "data" } }
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // A pattern that matches three wrapped envelopes in sequence.
+    let wrapped_3_pattern = Pattern::sequence(vec![
+        Pattern::wrapped(),
+        Pattern::wrapped(),
+        Pattern::wrapped(),
+    ]);
+    let paths = wrapped_3_pattern.paths(&wrapped_4);
+    // println!("{}", format_paths(&paths));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        25cb582c { { { { "data" } } } }
+            c1426a18 { { { "data" } } }
+                ee8cade0 { { "data" } }
+                    febc1555 { "data" }
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // A pattern that matches four wrapped envelopes in sequence.
+    let wrapped_4_pattern = Pattern::sequence(vec![
+        Pattern::wrapped(),
+        Pattern::wrapped(),
+        Pattern::wrapped(),
+        Pattern::wrapped(),
+    ]);
+    let paths = wrapped_4_pattern.paths(&wrapped_4);
+    // println!("{}", format_paths(&paths));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        25cb582c { { { { "data" } } } }
+            c1426a18 { { { "data" } } }
+                ee8cade0 { { "data" } }
+                    febc1555 { "data" }
+                        e909da9a "data"
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn optional_wrapped_pattern() {
+    // A pattern that matches an envelope that may or may not be wrapped.
+    let optional_wrapped_pattern = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 0..=1, Greediness::Greedy),
+        Pattern::any_number(),
+    ]);
+
+    let inner = Envelope::new(42);
+    let wrapped = inner.wrap_envelope();
+
+    let inner_paths = optional_wrapped_pattern.paths(&inner);
+    #[rustfmt::skip]
+    let expected  = indoc! {r#"
+        7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&inner_paths), expected);
+
+    let wrapped_paths = optional_wrapped_pattern.paths(&wrapped);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        58b1ac6a { 42 }
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&wrapped_paths), expected);
+}
+
+#[test]
+fn test_search_pattern() {
+    // A pattern that searches for any text in the envelope
+    let text_search_pattern = Pattern::search(Pattern::any_text());
+
+    // Test searching for text in a simple envelope
+    let envelope = Envelope::new("Alice")
+        .add_assertion("knows", "Bob")
+        .add_assertion("age", 30);
+
+    let text_search_paths = text_search_pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        a47bb3d4 "Alice" [ "age": 30, "knows": "Bob" ]
+        a47bb3d4 "Alice" [ "age": 30, "knows": "Bob" ]
+            13941b48 "Alice"
+        a47bb3d4 "Alice" [ "age": 30, "knows": "Bob" ]
+            0eb5609b "age": 30
+                5943be12 "age"
+        a47bb3d4 "Alice" [ "age": 30, "knows": "Bob" ]
+            78d666eb "knows": "Bob"
+                db7dd21c "knows"
+        a47bb3d4 "Alice" [ "age": 30, "knows": "Bob" ]
+            78d666eb "knows": "Bob"
+                13b74194 "Bob"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&text_search_paths), expected);
+
+    // A pattern that searches for the text "Bob" in the envelope
+    let bob_search_pattern = Pattern::search(Pattern::text("Bob"));
+    let bob_search_paths = bob_search_pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        a47bb3d4 "Alice" [ "age": 30, "knows": "Bob" ]
+            78d666eb "knows": "Bob"
+                13b74194 "Bob"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&bob_search_paths), expected);
+
+    // A pattern that searches for any number in the envelope
+    let number_search_pattern = Pattern::search(Pattern::any_number());
+    let number_search_paths = number_search_pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        a47bb3d4 "Alice" [ "age": 30, "knows": "Bob" ]
+            0eb5609b "age": 30
+                cf972730 30
+    "#}.trim();
+    assert_actual_expected!(format_paths(&number_search_paths), expected);
+
+    // A pattern that searches for any assertion with an object
+    // that is a number
+    let number_object_search_pattern =
+        Pattern::search(Pattern::assertion_with_object(Pattern::any_number()));
+    let number_object_search_paths =
+        number_object_search_pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        a47bb3d4 "Alice" [ "age": 30, "knows": "Bob" ]
+            0eb5609b "age": 30
+    "#}.trim();
+    assert_actual_expected!(
+        format_paths(&number_object_search_paths),
+        expected
+    );
+}
+
+#[test]
+fn test_search_pattern_nested() {
+    // A pattern that searches for any text in the envelope
+    let text_search_pattern = Pattern::search(Pattern::any_text());
+
+    // Test searching in a more complex nested envelope
+    let inner_envelope =
+        Envelope::new("Carol").add_assertion("title", "Engineer");
+
+    let envelope = Envelope::new("Alice")
+        .add_assertion("knows", inner_envelope)
+        .add_assertion("department", "Engineering");
+
+    // Search for all text should find text at all levels
+    let text_search_paths = text_search_pattern.paths(&envelope);
+
+    assert_eq!(text_search_paths.len(), 9);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+            13941b48 "Alice"
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+            2a26d42a "department": "Engineering"
+                8aaec3ab "department"
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+            2a26d42a "department": "Engineering"
+                71d7c10e "Engineering"
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+            c0c35c79 "knows": "Carol" [ "title": "Engineer" ]
+                db7dd21c "knows"
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+            c0c35c79 "knows": "Carol" [ "title": "Engineer" ]
+                59e8c540 "Carol" [ "title": "Engineer" ]
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+            c0c35c79 "knows": "Carol" [ "title": "Engineer" ]
+                59e8c540 "Carol" [ "title": "Engineer" ]
+                    afb8122e "Carol"
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+            c0c35c79 "knows": "Carol" [ "title": "Engineer" ]
+                59e8c540 "Carol" [ "title": "Engineer" ]
+                    a4d32c8f "title": "Engineer"
+                        d380cf3f "title"
+        a69103e9 "Alice" [ "department": "Engineering", "knows": "Carol" [ "title": "Engineer" ] ]
+            c0c35c79 "knows": "Carol" [ "title": "Engineer" ]
+                59e8c540 "Carol" [ "title": "Engineer" ]
+                    a4d32c8f "title": "Engineer"
+                        df9ac43f "Engineer"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&text_search_paths), expected);
+
+    // Verify we can find "Carol" nested inside
+    let carol_paths: Vec<_> = text_search_paths
+        .iter()
+        .filter(|path| path.last().unwrap().format_flat().contains("Carol"))
+        .collect();
+    assert_eq!(carol_paths.len(), 3); // Root envelope, Carol envelope, and Carol subject
+
+    // The path to "Carol" subject should be: envelope -> knows assertion ->
+    // Carol envelope -> "Carol"
+    let carol_subject_path = carol_paths
+        .iter()
+        .find(|path| path.last().unwrap().format_flat() == "\"Carol\"")
+        .unwrap();
+    assert_eq!(carol_subject_path.len(), 4);
+}
+
+#[test]
+fn test_search_pattern_with_wrapped() {
+    // A pattern that searches for the text "secret" in the envelope
+    let secret_text_search_pattern = Pattern::search(Pattern::text("secret"));
+
+    let inner =
+        Envelope::new("secret").add_assertion("classification", "top-secret");
+    let envelope =
+        Envelope::new("Alice").add_assertion("data", inner.wrap_envelope());
+
+    let secret_text_search_paths = secret_text_search_pattern.paths(&envelope);
+    // println!("{}", format_paths(&paths));
+    let expected = indoc! {r#"
+        1435493d "Alice" [ "data": { "secret" [ "classification": "top-secret" ] } ]
+            a5d4710e "data": { "secret" [ "classification": "top-secret" ] }
+                41dca0cd { "secret" [ "classification": "top-secret" ] }
+                    f66baec9 "secret" [ "classification": "top-secret" ]
+        1435493d "Alice" [ "data": { "secret" [ "classification": "top-secret" ] } ]
+            a5d4710e "data": { "secret" [ "classification": "top-secret" ] }
+                41dca0cd { "secret" [ "classification": "top-secret" ] }
+                    f66baec9 "secret" [ "classification": "top-secret" ]
+                        fa445f41 "secret"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&secret_text_search_paths), expected);
+
+    // A pattern that searches for any text containing the word "secret"
+    let secret_regex_search_pattern = Pattern::search(Pattern::text_regex(
+        regex::Regex::new("secret").unwrap(),
+    ));
+    let secret_regex_search_paths =
+        secret_regex_search_pattern.paths(&envelope);
+    let expected = indoc! {r#"
+        1435493d "Alice" [ "data": { "secret" [ "classification": "top-secret" ] } ]
+            a5d4710e "data": { "secret" [ "classification": "top-secret" ] }
+                41dca0cd { "secret" [ "classification": "top-secret" ] }
+                    f66baec9 "secret" [ "classification": "top-secret" ]
+        1435493d "Alice" [ "data": { "secret" [ "classification": "top-secret" ] } ]
+            a5d4710e "data": { "secret" [ "classification": "top-secret" ] }
+                41dca0cd { "secret" [ "classification": "top-secret" ] }
+                    f66baec9 "secret" [ "classification": "top-secret" ]
+                        fa445f41 "secret"
+        1435493d "Alice" [ "data": { "secret" [ "classification": "top-secret" ] } ]
+            a5d4710e "data": { "secret" [ "classification": "top-secret" ] }
+                41dca0cd { "secret" [ "classification": "top-secret" ] }
+                    f66baec9 "secret" [ "classification": "top-secret" ]
+                        7e14bb9e "classification": "top-secret"
+                            c2d8f15f "top-secret"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&secret_regex_search_paths), expected);
+}
+
+#[cfg(feature = "signature")]
+#[test]
+fn test_search_pattern_credential() {
+    use crate::common::test_data::credential;
+
+    // A pattern that searches for any text in the envelepe
+    let text_search_pattern = Pattern::search(Pattern::any_text());
+
+    let cred = credential();
+    // println!("{}", cred.tree_format());
+    let expected = indoc! {r#"
+        0b721f78 NODE
+            397a2d4c subj WRAPPED
+                8122ffa9 subj NODE
+                    10d3de01 subj ARID(4676635a)
+                    1f9ff098 ASSERTION
+                        9e3bff3a pred "certificateNumber"
+                        21c21808 obj "123-456-789"
+                    36c254d0 ASSERTION
+                        6e5d379f pred "expirationDate"
+                        639ae9bf obj 2028-01-01
+                    3c114201 ASSERTION
+                        5f82a16a pred "lastName"
+                        fe4d5230 obj "Maxwell"
+                    4a9b2e4d ASSERTION
+                        222afe69 pred "issueDate"
+                        cb67f31d obj 2020-01-01
+                    4d67bba0 ASSERTION
+                        2be2d79b pred 'isA'
+                        051beee6 obj "Certificate of Completion"
+                    5171cbaf ASSERTION
+                        3976ef74 pred "photo"
+                        231b8527 obj "This is James Maxwell's photo."
+                    54b3e1e7 ASSERTION
+                        f13aa855 pred "professionalDevelopmentHours"
+                        dc0e9c36 obj 15
+                    5dc6d4e3 ASSERTION
+                        4395643b pred "firstName"
+                        d6d0b768 obj "James"
+                    68895d8e ASSERTION
+                        e6bf4dd3 pred "topics"
+                        543fcc09 obj ["Subject 1", "Subject 2"]
+                    8ec5e912 ASSERTION
+                        2b191589 pred "continuingEducationUnits"
+                        4bf5122f obj 1
+                    9b3d4785 ASSERTION
+                        af10ee92 pred 'controller'
+                        f8489ac1 obj "Example Electrical Engineering Board"
+                    caf5ced3 ASSERTION
+                        8e4e62eb pred "subject"
+                        202c10ef obj "RF and Microwave Engineering"
+                    d3e0cc15 ASSERTION
+                        6dd16ba3 pred 'issuer'
+                        f8489ac1 obj "Example Electrical Engineering Board"
+            46a02aaf ASSERTION
+                d0e39e78 pred 'signed'
+                34c14941 obj Signature
+            e6d7fca0 ASSERTION
+                0fcd6a39 pred 'note'
+                f106bad1 obj "Signed by Example Electrical Engineering…"
+    "#}
+    .trim();
+    assert_actual_expected!(cred.tree_format(), expected);
+
+    // Search for all text in the credential
+    let text_paths = text_search_pattern.paths(&cred);
+    // Get the last element of each path as a single-element path for output
+    let found_elements: Vec<Path> = text_paths
+        .iter()
+        .map(|path| vec![(*path.last().unwrap()).clone()])
+        .collect();
+    let expected = indoc! {r#"
+        9e3bff3a "certificateNumber"
+        21c21808 "123-456-789"
+        6e5d379f "expirationDate"
+        5f82a16a "lastName"
+        fe4d5230 "Maxwell"
+        222afe69 "issueDate"
+        051beee6 "Certificate of Completion"
+        3976ef74 "photo"
+        231b8527 "This is James Maxwell's photo."
+        f13aa855 "professionalDevelopmentHours"
+        4395643b "firstName"
+        d6d0b768 "James"
+        e6bf4dd3 "topics"
+        2b191589 "continuingEducationUnits"
+        f8489ac1 "Example Electrical Engineering Board"
+        8e4e62eb "subject"
+        202c10ef "RF and Microwave Engineering"
+        f8489ac1 "Example Electrical Engineering Board"
+        f106bad1 "Signed by Example Electrical Engineering Board"
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&found_elements), expected);
+
+    // A pattern that searches for the text "James" in the credential
+    let james_search_pattern = Pattern::search(Pattern::text("James"));
+    // Search for specific strings that should be in the credential
+    let james_paths = james_search_pattern.paths(&cred);
+    assert_eq!(james_paths.len(), 1);
+
+    // A pattern that searches for the text "Maxwell" in the credential
+    let maxwell_search_pattern = Pattern::search(Pattern::text("Maxwell"));
+    let maxwell_paths = maxwell_search_pattern.paths(&cred);
+    assert_eq!(maxwell_paths.len(), 1);
+
+    // A pattern that searches for numbers in the credential
+    let number_search_pattern =
+        Pattern::search(Pattern::assertion_with_object(Pattern::any_number()));
+    // Should find education units and hours
+    let number_paths = number_search_pattern.paths(&cred);
+    // Get the last element of each path as a single-element path for output
+    let number_paths: Vec<Path> = number_paths
+        .iter()
+        .map(|path| vec![(*path.last().unwrap()).clone()])
+        .collect();
+    let expected = indoc! {r#"
+        54b3e1e7 "professionalDevelopmentHours": 15
+        8ec5e912 "continuingEducationUnits": 1
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&number_paths), expected);
+}
+
+#[test]
+fn test_not_pattern() {
+    // Create a test envelope
+    let envelope = Envelope::new("test_subject")
+        .add_assertion("key1", "value1")
+        .add_assertion("key2", "value2")
+        .add_assertion("number", 42);
+
+    // Test not pattern with text pattern that doesn't match
+    let not_matches = Pattern::not_matching(Pattern::text("non_matching_text"))
+        .matches(&envelope);
+    assert!(
+        not_matches,
+        "Should match when the inner pattern doesn't match"
+    );
+
+    // Test not pattern with text pattern that does match
+    let not_matches =
+        Pattern::not_matching(Pattern::text("test_subject")).matches(&envelope);
+    assert!(
+        !not_matches,
+        "Should not match when the inner pattern matches"
+    );
+
+    // Test not pattern with object pattern - this should find no matches
+    // because we have an assertion with object 42
+    let not_patterns = Pattern::search(Pattern::not_matching(Pattern::object(
+        Pattern::number(42),
+    )))
+    .paths(&envelope);
+
+    // Should not match the assertion with object 42, but will match other
+    // elements
+    let found_objects = not_patterns
+        .iter()
+        .filter(|path| path.last().unwrap().is_assertion())
+        .filter_map(|path| {
+            let assertion = path.last().unwrap();
+            if let Ok(obj) = assertion.extract_object::<i32>() {
+                Some(obj)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        !found_objects.contains(&42),
+        "Should not match assertions with object 42"
+    );
+
+    // Test combination of not pattern with other patterns
+    let complex_pattern = Pattern::and(vec![
+        Pattern::not_matching(Pattern::text("wrong_subject")),
+        Pattern::assertion_with_predicate(Pattern::text("key1")),
+    ]);
+
+    let matches = complex_pattern.matches(&envelope);
+    assert!(matches, "Complex pattern with not should match");
+
+    // The path includes the assertion for a successful not pattern
+    let pattern = Pattern::not_matching(Pattern::text("wrong"));
+    let paths = pattern.paths(&envelope);
+
+    // Instead of checking exact digest (which can change), check the content
+    assert_eq!(paths.len(), 1, "Should have one path");
+    let returned_envelope = paths[0][0].clone();
+    assert_eq!(
+        returned_envelope.extract_subject::<String>().unwrap(),
+        "test_subject"
+    );
+}
+
+#[test]
+fn test_not_pattern_with_search() {
+    // Create a nested envelope structure
+    let inner_envelope =
+        Envelope::new("inner").add_assertion("inner_key", "inner_value");
+
+    let outer_envelope =
+        Envelope::new("outer").add_assertion("contains", inner_envelope);
+
+    // Search for elements that are NOT obscured (everything in this case)
+    let not_obscured_paths =
+        Pattern::search(Pattern::not_matching(Pattern::obscured()))
+            .paths(&outer_envelope);
+
+    // We should find multiple matches (everything, since nothing is obscured)
+    assert!(
+        !not_obscured_paths.is_empty(),
+        "Should find elements that are not obscured"
+    );
+
+    // Create envelope with elided content
+    let envelope_with_elided = Envelope::new("test")
+        .add_assertion("visible", "data")
+        .add_assertion("hidden", Envelope::new("secret").elide());
+
+    // Search for elements that are NOT elided
+    let not_elided_paths =
+        Pattern::search(Pattern::not_matching(Pattern::obscured()))
+            .paths(&envelope_with_elided);
+
+    // Should find multiple elements that are not elided
+    assert!(
+        !not_elided_paths.is_empty(),
+        "Should find elements that are not elided"
+    );
+
+    // Verify we didn't match the elided element
+    for path in &not_elided_paths {
+        if let Some(element) = path.last() {
+            assert!(!element.is_elided(), "Should not match elided elements");
+        }
+    }
+}

--- a/bc-envelope-pattern/tests/pattern_tests_repeat.rs
+++ b/bc-envelope-pattern/tests/pattern_tests_repeat.rs
@@ -1,0 +1,548 @@
+mod common;
+
+use bc_envelope::prelude::*;
+use bc_envelope_pattern::{Matcher, Pattern, Greediness};
+use indoc::indoc;
+
+use crate::common::pattern_utils::format_paths;
+
+fn fold(string: &str) -> Envelope {
+    let chars: Vec<String> = string.chars().map(|c| c.to_string()).collect();
+    let mut it = chars.into_iter().enumerate().rev();
+    let (index, c) = it.next().unwrap();
+    let mut env = Envelope::new_assertion(index, c);
+    for (index, c) in it {
+        let obj = Envelope::new(c.clone())
+            .add_assertion_envelope(env)
+            .unwrap();
+        env = Envelope::new_assertion(index, obj);
+    }
+    Envelope::unit().add_assertion_envelope(env).unwrap()
+}
+
+fn unfold(env: impl AsRef<Envelope>) -> String {
+    let mut result = String::new();
+    let mut env = Some(env.as_ref().clone());
+    while let Some(e) = env {
+        if e.is_assertion() {
+            let object = e.as_object().unwrap();
+            let c: String = object.extract_subject().unwrap();
+            result.push_str(&c);
+            env = object.assertions().first().cloned();
+        } else {
+            env = e.assertions().first().cloned();
+        }
+    }
+    result
+}
+
+#[test]
+fn test_fold() {
+    bc_envelope::register_tags();
+
+    let s = "hello";
+    let folded = fold(s);
+
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        '' [
+            0: "h" [
+                1: "e" [
+                    2: "l" [
+                        3: "l" [
+                            4: "o"
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    "#}.trim();
+    assert_actual_expected!(folded.format(), expected);
+
+    #[rustfmt::skip]
+    let expected =  indoc! {r#"
+        b229d3cb NODE
+            934312d6 subj ''
+            1b47f7a1 ASSERTION
+                6e340b9c pred 0
+                dc1d9ddc obj NODE
+                    70a0d519 subj "h"
+                    354b5ed3 ASSERTION
+                        4bf5122f pred 1
+                        a899ff63 obj NODE
+                            f9a00f43 subj "e"
+                            7e272ce6 ASSERTION
+                                dbc1b4c9 pred 2
+                                bff05dca obj NODE
+                                    63518250 subj "l"
+                                    d71e5aaf ASSERTION
+                                        084fed08 pred 3
+                                        73381991 obj NODE
+                                            63518250 subj "l"
+                                            7c92231b ASSERTION
+                                                e52d9c50 pred 4
+                                                2dd41130 obj "o"
+    "#}.trim();
+    assert_actual_expected!(folded.tree_format(), expected);
+
+    let unfolded = unfold(folded);
+    assert_eq!(unfolded, s);
+}
+
+#[test]
+fn repeat_test() {
+    bc_envelope::register_tags();
+
+    let s = "hello";
+    let env = fold(s);
+
+    let paths = Pattern::sequence(vec![Pattern::any_assertion()]).paths(&env);
+    assert_eq!(unfold(paths[0].last().unwrap()), s);
+
+    let assertion_object_pattern = Pattern::sequence(vec![
+        Pattern::any_assertion(),
+        Pattern::any_object(),
+    ]);
+
+    let paths =
+        Pattern::repeat(assertion_object_pattern, 3..=3, Greediness::Greedy)
+            .paths(&env);
+    assert_eq!(paths.len(), 1);
+    println!("{}", format_paths(&paths));
+
+    let path = &paths[0];
+    assert_eq!(transpose(path), "hel");
+    assert_eq!(unfold(path.last().unwrap()), "lo");
+    for element in path {
+        println!("{}", unfold(element));
+    }
+}
+
+#[test]
+fn test_repeat_2() {
+    let str = "AabBbabB";
+    let env = fold(str);
+
+    let seq_a = Pattern::sequence(vec![
+        Pattern::assertion_with_object(Pattern::text("A")),
+        Pattern::any_object(),
+    ]);
+
+    let seq_any = Pattern::sequence(vec![
+        Pattern::any_assertion(),
+        Pattern::any_object(),
+    ]);
+
+    let seq_b = Pattern::sequence(vec![
+        Pattern::assertion_with_object(Pattern::text("B")),
+        Pattern::any_object(),
+    ]);
+
+    let pat = |mode| Pattern::sequence(vec![
+        seq_a.clone(),
+        Pattern::repeat(seq_any.clone(), .., mode),
+        seq_b.clone(),
+    ]);
+
+    let paths = pat(Greediness::Greedy).paths(&env);
+    println!("\nGreedy:\n{}", format_paths(&paths));
+
+    let paths = pat(Greediness::Lazy).paths(&env);
+    println!("\nLazy:\n{}", format_paths(&paths));
+
+    let paths = pat(Greediness::Possessive).paths(&env);
+    println!("\nPossessive:\n{}", format_paths(&paths));
+}
+
+fn transpose(path: impl AsRef<Path>) -> String {
+    path.as_ref().iter().filter_map(|e| e.subject().as_text()).collect::<Vec<_>>().join("")
+}
+
+fn wrap_n(mut env: Envelope, n: usize) -> Envelope {
+    for _ in 0..n {
+        env = env.wrap_envelope();
+    }
+    env
+}
+
+#[test]
+fn repeat_any_greedy() {
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), .., Greediness::Greedy),
+        Pattern::any_cbor(),
+    ]);
+
+    let env = wrap_n(Envelope::new(42), 4);
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        3a0b1e87 { { { { 42 } } } }
+            75659622 { { { 42 } } }
+                81bb1f5e { { 42 } }
+                    58b1ac6a { 42 }
+                        7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_any_lazy() {
+    let env = wrap_n(Envelope::new(42), 4);
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), .., Greediness::Lazy),
+        Pattern::any_cbor(),
+    ]);
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        3a0b1e87 { { { { 42 } } } }
+            75659622 { { { 42 } } }
+                81bb1f5e { { 42 } }
+                    58b1ac6a { 42 }
+                        7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_any_possessive() {
+    let env = wrap_n(Envelope::new(42), 4);
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), .., Greediness::Possessive),
+        Pattern::any_cbor(),
+    ]);
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        3a0b1e87 { { { { 42 } } } }
+            75659622 { { { 42 } } }
+                81bb1f5e { { 42 } }
+                    58b1ac6a { 42 }
+                        7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_some_greedy() {
+    let env = wrap_n(Envelope::new(42), 3);
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 1.., Greediness::Greedy),
+        Pattern::any_cbor(),
+    ]);
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        75659622 { { { 42 } } }
+            81bb1f5e { { 42 } }
+                58b1ac6a { 42 }
+                    7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_some_lazy() {
+    let env = wrap_n(Envelope::new(42), 3);
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 1.., Greediness::Lazy),
+        Pattern::any_cbor(),
+    ]);
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        75659622 { { { 42 } } }
+            81bb1f5e { { 42 } }
+                58b1ac6a { 42 }
+                    7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_some_possessive() {
+    let env = wrap_n(Envelope::new(42), 3);
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 1.., Greediness::Possessive),
+        Pattern::any_cbor(),
+    ]);
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        75659622 { { { 42 } } }
+            81bb1f5e { { 42 } }
+                58b1ac6a { 42 }
+                    7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_optional_greedy() {
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 0..=1, Greediness::Greedy),
+        Pattern::any_cbor(),
+    ]);
+    let paths = pat.paths(&wrap_n(Envelope::new(42), 0));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    let paths = pat.paths(&wrap_n(Envelope::new(42), 1));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        58b1ac6a { 42 }
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_optional_lazy() {
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 0..=1, Greediness::Lazy),
+        Pattern::any_cbor(),
+    ]);
+    let paths = pat.paths(&wrap_n(Envelope::new(42), 0));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+    let paths = pat.paths(&wrap_n(Envelope::new(42), 1));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        58b1ac6a { 42 }
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_optional_possessive() {
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 0..=1, Greediness::Possessive),
+        Pattern::any_cbor(),
+    ]);
+    let paths = pat.paths(&wrap_n(Envelope::new(42), 0));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+    let paths = pat.paths(&wrap_n(Envelope::new(42), 1));
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        58b1ac6a { 42 }
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_range_greedy() {
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 2..=3, Greediness::Greedy),
+        Pattern::any_cbor(),
+    ]);
+    let env = wrap_n(Envelope::new(42), 3);
+    assert!(pat.matches(&env));
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        75659622 { { { 42 } } }
+            81bb1f5e { { 42 } }
+                58b1ac6a { 42 }
+                    7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_range_lazy() {
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 2..=3, Greediness::Lazy),
+        Pattern::any_cbor(),
+    ]);
+    let env = wrap_n(Envelope::new(42), 3);
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        75659622 { { { 42 } } }
+            81bb1f5e { { 42 } }
+                58b1ac6a { 42 }
+                    7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_range_possessive() {
+    let pat = Pattern::sequence(vec![
+        Pattern::repeat(Pattern::wrapped(), 2..=3, Greediness::Possessive),
+        Pattern::any_cbor(),
+    ]);
+    let env = wrap_n(Envelope::new(42), 3);
+    let paths = pat.paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        75659622 { { { 42 } } }
+            81bb1f5e { { 42 } }
+                58b1ac6a { 42 }
+                    7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn repeat_any_modes() {
+    let env = wrap_n(Envelope::new("data"), 2);
+
+    let pat = |mode| {
+        Pattern::sequence(vec![
+            Pattern::repeat(Pattern::wrapped(), 0.., mode),
+            Pattern::wrapped(),
+            Pattern::text("data"),
+        ])
+    };
+
+    let greedy_paths = pat(Greediness::Greedy).paths(&env);
+    let lazy_paths = pat(Greediness::Lazy).paths(&env);
+    let possessive_paths = pat(Greediness::Possessive).paths(&env);
+
+    assert_eq!(greedy_paths, lazy_paths);
+    assert!(possessive_paths.is_empty());
+
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        ee8cade0 { { "data" } }
+            febc1555 { "data" }
+                e909da9a "data"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&greedy_paths), expected);
+}
+
+#[test]
+fn repeat_optional_modes() {
+    let env = wrap_n(Envelope::new(42), 1);
+
+    let pat = |mode| {
+        Pattern::sequence(vec![
+            Pattern::repeat(Pattern::wrapped(), 0..=1, mode),
+            Pattern::number(42),
+        ])
+    };
+
+    let greedy_paths = pat(Greediness::Greedy).paths(&env);
+    let expected = indoc! {r#"
+        58b1ac6a { 42 }
+            7f83f7bd 42
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&greedy_paths), expected);
+
+    let lazy_paths = pat(Greediness::Lazy).paths(&env);
+    let expected = indoc! {r#"
+        58b1ac6a { 42 }
+            7f83f7bd 42
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&lazy_paths), expected);
+
+    let possessive_paths = pat(Greediness::Possessive).paths(&env);
+    let expected = indoc! {r#"
+        58b1ac6a { 42 }
+            7f83f7bd 42
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&possessive_paths), expected);
+}
+
+#[test]
+fn repeat_some_order() {
+    let env = wrap_n(Envelope::new("x"), 2);
+
+    let expected = indoc! {r#"
+        06bb2465 WRAPPED
+            70b5f17d subj WRAPPED
+                5e85370e subj "x"
+    "#}
+    .trim();
+    assert_actual_expected!(env.tree_format(), expected);
+
+    let pat = |mode| {
+        Pattern::sequence(vec![
+            Pattern::repeat(Pattern::wrapped(), 1.., mode),
+            Pattern::subject(),
+        ])
+    };
+
+    let greedy_paths = pat(Greediness::Greedy).paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        06bb2465 { { "x" } }
+            70b5f17d { "x" }
+                5e85370e "x"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&greedy_paths), expected);
+
+    let lazy_paths = pat(Greediness::Lazy).paths(&env);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        06bb2465 { { "x" } }
+            70b5f17d { "x" }
+    "#}.trim();
+    assert_actual_expected!(format_paths(&lazy_paths), expected);
+
+    let possessive_paths = pat(Greediness::Possessive).paths(&env);
+    let expected = indoc! {r#"
+        06bb2465 { { "x" } }
+            70b5f17d { "x" }
+                5e85370e "x"
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&possessive_paths), expected);
+}
+
+#[test]
+fn repeat_range_order() {
+    let env = wrap_n(Envelope::new("x"), 4);
+
+    let pat = |mode| {
+        Pattern::sequence(vec![
+            Pattern::repeat(Pattern::wrapped(), 2..=3, mode),
+            Pattern::subject(),
+        ])
+    };
+
+    let greedy_paths = pat(Greediness::Greedy).paths(&env);
+    let expected = indoc! {r#"
+        88e28c8b { { { { "x" } } } }
+            79962374 { { { "x" } } }
+                06bb2465 { { "x" } }
+                    70b5f17d { "x" }
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&greedy_paths), expected);
+
+    let lazy_paths = pat(Greediness::Lazy).paths(&env);
+    let expected = indoc! {r#"
+        88e28c8b { { { { "x" } } } }
+            79962374 { { { "x" } } }
+                06bb2465 { { "x" } }
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&lazy_paths), expected);
+
+    let possessive_paths = pat(Greediness::Possessive).paths(&env);
+    let expected = indoc! {r#"
+        88e28c8b { { { { "x" } } } }
+            79962374 { { { "x" } } }
+                06bb2465 { { "x" } }
+                    70b5f17d { "x" }
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&possessive_paths), expected);
+}

--- a/bc-envelope-pattern/tests/pattern_tests_structure.rs
+++ b/bc-envelope-pattern/tests/pattern_tests_structure.rs
@@ -1,0 +1,438 @@
+mod common;
+
+use bc_envelope::prelude::*;
+use bc_envelope_pattern::{Matcher, Pattern};
+use indoc::indoc;
+
+use crate::common::pattern_utils::*;
+
+#[test]
+fn test_subject_pattern() {
+    let envelope = Envelope::new("Alice");
+
+    let pat = Pattern::subject();
+    let matching_paths = pat.paths(&envelope);
+
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        13941b48 "Alice"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&matching_paths), expected);
+
+    let envelope_with_assertions = envelope.add_assertion("knows", "Bob");
+    let matching_paths = pat.paths(&envelope_with_assertions);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        8955db5e "Alice" [ "knows": "Bob" ]
+            13941b48 "Alice"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&matching_paths), expected);
+}
+
+#[test]
+fn test_wrapped_pattern() {
+    // Does not match non-wrapped subjects.
+    let envelope = Envelope::new(42);
+    assert!(!Pattern::wrapped().matches(&envelope));
+
+    // Matches a wrapped envelope with any subject.
+    let wrapped_envelope = envelope.wrap_envelope();
+    let paths = Pattern::wrapped().paths(&wrapped_envelope);
+    // println!("{}", format_paths(&paths));
+    let expected = indoc! {r#"
+        58b1ac6a { 42 }
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // The matched paths include the assertion.
+    let wrapped_envelope_with_assertion = wrapped_envelope.add_assertion("an", "assertion");
+    let paths = Pattern::wrapped().paths(&wrapped_envelope_with_assertion);
+    // println!("{}", format_paths(&paths));
+    let expected = indoc! {r#"
+        169aba00 { 42 } [ "an": "assertion" ]
+            7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    let wrapped_twice = wrapped_envelope_with_assertion.wrap_envelope();
+    // Matching a wrapped envelope with assertions returns a path where the first
+    // element is the original wrapped envelope including assertions, and the
+    // second element is the still-wrapped subject.
+    let paths = Pattern::wrapped().paths(&wrapped_twice);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        52d47c15 { { 42 } [ "an": "assertion" ] }
+            169aba00 { 42 } [ "an": "assertion" ]
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    let wrapped_twice_pattern = Pattern::sequence(vec![
+        Pattern::wrapped(),
+        Pattern::wrapped(),
+    ]);
+    let paths = wrapped_twice_pattern.paths(&wrapped_twice);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        52d47c15 { { 42 } [ "an": "assertion" ] }
+            169aba00 { 42 } [ "an": "assertion" ]
+                7f83f7bd 42
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_assertion_pattern() {
+    let envelope_without_assertions = Envelope::new("Alice");
+
+    // Does not match envelopes without assertions.
+    assert!(!Pattern::any_assertion().matches(&envelope_without_assertions));
+
+    let envelope_with_assertions = envelope_without_assertions
+        .add_assertion("knows", "Bob")
+        .add_assertion("worksWith", "Charlie");
+
+    // Returns a path for each assertion in the envelope.
+    let paths = Pattern::any_assertion().paths(&envelope_with_assertions);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        78d666eb "knows": "Bob"
+        c269cf0a "worksWith": "Charlie"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_assertion_predicate_pattern() {
+    let envelope = Envelope::new("Alice")
+        .add_assertion("knows", "Bob")
+        .add_assertion("knows", "Charlie")
+        .add_assertion("worksWith", "David");
+
+    // Returns a path for each assertion with a predicate that matches
+    // the specified pattern.
+    let paths = Pattern::assertion_with_predicate(Pattern::text("knows"))
+        .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        78d666eb "knows": "Bob"
+        7af83724 "knows": "Charlie"
+    "#}.trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    let pattern = Pattern::sequence(vec![
+        Pattern::assertion_with_predicate(Pattern::text("knows")),
+        Pattern::any_object(),
+    ]);
+    let paths = pattern.paths(&envelope);
+    #[rustfmt::skip]
+    let expected = indoc! {r#"
+        78d666eb "knows": "Bob"
+            13b74194 "Bob"
+        7af83724 "knows": "Charlie"
+            ee8e3b02 "Charlie"
+    "#}
+    .trim();
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_digest_pattern() {
+    let envelope = Envelope::new("Hello, World!");
+    let digest = envelope.digest().into_owned();
+    let hex_digest = hex::encode(digest.as_bytes());
+    let prefix = &hex_digest[0..8];
+
+    // Test exact digest matching
+    assert!(Pattern::digest(digest.clone()).matches(&envelope));
+    assert!(!Pattern::digest(Digest::from_data([0; 32])).matches(&envelope));
+
+    // Test hex prefix matching
+    assert!(Pattern::digest_hex_prefix(prefix).matches(&envelope));
+    assert!(Pattern::digest_hex_prefix(&hex_digest).matches(&envelope));
+    assert!(!Pattern::digest_hex_prefix("ffffffff").matches(&envelope));
+
+    // Test with envelope that has assertions
+    let envelope_with_assertions =
+        envelope.clone().add_assertion("test", "value");
+    let digest_with_assertions = envelope_with_assertions.digest().into_owned();
+
+    assert!(
+        !Pattern::digest(digest.clone()).matches(&envelope_with_assertions)
+    );
+    assert!(
+        Pattern::digest(digest_with_assertions.clone())
+            .matches(&envelope_with_assertions)
+    );
+
+    // Test paths
+    let paths = Pattern::digest(digest.clone()).paths(&envelope);
+    #[rustfmt::skip]
+    let expected = format!(
+        "{} \"Hello, World!\"",
+        envelope.short_id(DigestDisplayFormat::Short)
+    );
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // No match should return empty paths
+    let paths = Pattern::digest(Digest::from_data([0; 32])).paths(&envelope);
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn test_digest_pattern_binary_regex() {
+    let envelope = Envelope::new("Hello, World!");
+    let digest = envelope.digest().into_owned();
+    let digest_bytes = digest.data();
+
+    // IMPORTANT: Binary regex patterns must use the (?s-u) flags to work
+    // correctly with arbitrary bytes:
+    // - (?s) allows '.' to match newline characters (like 0x0a)
+    // - (?-u) disables unicode mode so '.' matches any byte, not just valid
+    //   UTF-8 sequences
+    // Without these flags, patterns like ^.{32}$ will fail on digest bytes
+    // containing newlines or invalid UTF-8 sequences (which are common in
+    // SHA-256 digests).
+
+    // Test regex matching any 32 bytes (should match any valid digest)
+    // NOTE: Need (?s-u) flags to handle all bytes including newlines and
+    // invalid UTF-8
+    let any_32_bytes_regex =
+        regex::bytes::Regex::new(r"(?s-u)^.{32}$").unwrap();
+    assert!(
+        Pattern::digest_binary_regex(any_32_bytes_regex).matches(&envelope)
+    );
+
+    // Test regex that shouldn't match (all zeros, 32 bytes)
+    let all_zeros_regex =
+        regex::bytes::Regex::new(r"(?s-u)^\x00{32}$").unwrap();
+    assert!(!Pattern::digest_binary_regex(all_zeros_regex).matches(&envelope));
+
+    // Test regex matching specific byte values using hex escapes
+    let first_byte_hex = format!(r"(?s-u)^\x{:02x}", digest_bytes[0]);
+    let starts_with_first_byte =
+        regex::bytes::Regex::new(&first_byte_hex).unwrap();
+    assert!(
+        Pattern::digest_binary_regex(starts_with_first_byte).matches(&envelope)
+    );
+
+    // Test regex for exact first two bytes
+    let first_two_bytes_pattern =
+        format!(r"(?s-u)^\x{:02x}\x{:02x}", digest_bytes[0], digest_bytes[1]);
+    let exact_first_two =
+        regex::bytes::Regex::new(&first_two_bytes_pattern).unwrap();
+    assert!(Pattern::digest_binary_regex(exact_first_two).matches(&envelope));
+
+    // Test regex matching any byte in range (should match digests with varied
+    // byte values)
+    let any_byte_range =
+        regex::bytes::Regex::new(r"(?s-u)[\x00-\xFF]").unwrap();
+    assert!(Pattern::digest_binary_regex(any_byte_range).matches(&envelope));
+
+    // Test complex pattern - match digests that start with a non-zero byte
+    let non_zero_start =
+        regex::bytes::Regex::new(r"(?s-u)^[\x01-\xFF]").unwrap();
+    let should_match = digest_bytes[0] != 0;
+    assert_eq!(
+        Pattern::digest_binary_regex(non_zero_start).matches(&envelope),
+        should_match
+    );
+
+    // Test paths for matching regex
+    let paths = Pattern::digest_binary_regex(
+        regex::bytes::Regex::new(r"(?s-u)^.{32}$").unwrap(),
+    )
+    .paths(&envelope);
+    #[rustfmt::skip]
+    let expected = format!(
+        "{} \"Hello, World!\"",
+        envelope.short_id(DigestDisplayFormat::Short)
+    );
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // Test paths for non-matching regex
+    let paths = Pattern::digest_binary_regex(
+        regex::bytes::Regex::new(r"(?s-u)^\x00{32}$").unwrap(),
+    )
+    .paths(&envelope);
+    assert!(paths.is_empty());
+
+    // Test with different envelope to ensure digest changes
+    let envelope2 = Envelope::new("Different content");
+    let digest2 = envelope2.digest().into_owned();
+
+    // Verify the digests are actually different
+    assert_ne!(digest.data(), digest2.data());
+
+    // Test a pattern that matches both (any 32 bytes)
+    let any_digest_regex = regex::bytes::Regex::new(r"(?s-u)^.{32}$").unwrap();
+    assert!(
+        Pattern::digest_binary_regex(any_digest_regex.clone())
+            .matches(&envelope)
+    );
+    assert!(Pattern::digest_binary_regex(any_digest_regex).matches(&envelope2));
+
+    // Test pattern that matches based on content
+    // Looking for digests containing specific byte sequences
+    let contains_aa = regex::bytes::Regex::new(r"(?s-u)\xaa").unwrap();
+    let envelope1_has_aa = digest_bytes.contains(&0xaa);
+    assert_eq!(
+        Pattern::digest_binary_regex(contains_aa.clone()).matches(&envelope),
+        envelope1_has_aa
+    );
+
+    let digest2_bytes = digest2.data();
+    let envelope2_has_aa = digest2_bytes.contains(&0xaa);
+    assert_eq!(
+        Pattern::digest_binary_regex(contains_aa).matches(&envelope2),
+        envelope2_has_aa
+    );
+
+    // Test edge cases with different digest patterns
+    let pattern_32_ascending =
+        regex::bytes::Regex::new(r"(?s-u)^[\x00-\x1F]{32}$").unwrap();
+    let has_low_bytes = digest_bytes.iter().all(|&b| b <= 0x1F);
+    assert_eq!(
+        Pattern::digest_binary_regex(pattern_32_ascending).matches(&envelope),
+        has_low_bytes
+    );
+
+    // Test pattern that looks for high-bit bytes
+    let pattern_high_bit =
+        regex::bytes::Regex::new(r"(?s-u)[\x80-\xFF]").unwrap();
+    let has_high_bit = digest_bytes.iter().any(|&b| b >= 0x80);
+    assert_eq!(
+        Pattern::digest_binary_regex(pattern_high_bit).matches(&envelope),
+        has_high_bit
+    );
+
+    // Test envelope with assertions (should match differently)
+    let envelope_with_assertions =
+        envelope.clone().add_assertion("test", "value");
+    let digest_with_assertions = envelope_with_assertions.digest().into_owned();
+
+    // Should still match 32-byte pattern
+    let universal_pattern = regex::bytes::Regex::new(r"(?s-u)^.{32}$").unwrap();
+    assert!(
+        Pattern::digest_binary_regex(universal_pattern)
+            .matches(&envelope_with_assertions)
+    );
+
+    // But digests should be different
+    assert_ne!(digest.data(), digest_with_assertions.data());
+}
+
+#[test]
+fn test_node_pattern() {
+    // Test with leaf (non-node) envelope
+    let leaf_envelope = Envelope::new("Just a leaf");
+    assert!(!Pattern::any_node().matches(&leaf_envelope));
+    assert!(
+        !Pattern::node_with_assertions_count_range(1..=3)
+            .matches(&leaf_envelope)
+    );
+    assert!(!Pattern::node_with_assertions_count(1).matches(&leaf_envelope));
+
+    // Test with single assertion node
+    let single_assertion_envelope =
+        Envelope::new("Alice").add_assertion("knows", "Bob");
+    assert!(Pattern::any_node().matches(&single_assertion_envelope));
+    assert!(
+        Pattern::node_with_assertions_count_range(1..=3)
+            .matches(&single_assertion_envelope)
+    );
+    assert!(
+        Pattern::node_with_assertions_count(1)
+            .matches(&single_assertion_envelope)
+    );
+    assert!(
+        !Pattern::node_with_assertions_count(2)
+            .matches(&single_assertion_envelope)
+    );
+
+    // Test with multiple assertions node
+    let multi_assertion_envelope = single_assertion_envelope
+        .add_assertion("age", 25)
+        .add_assertion("city", "New York");
+    assert!(Pattern::any_node().matches(&multi_assertion_envelope));
+    assert!(
+        Pattern::node_with_assertions_count_range(1..=5)
+            .matches(&multi_assertion_envelope)
+    );
+    assert!(
+        Pattern::node_with_assertions_count(3)
+            .matches(&multi_assertion_envelope)
+    );
+    assert!(
+        !Pattern::node_with_assertions_count(2)
+            .matches(&multi_assertion_envelope)
+    );
+    assert!(
+        !Pattern::node_with_assertions_count_range(4..=5)
+            .matches(&multi_assertion_envelope)
+    );
+
+    // Test paths
+    let paths = Pattern::any_node().paths(&single_assertion_envelope);
+    #[rustfmt::skip]
+    let expected = format!(
+        r#"{} "Alice" [ "knows": "Bob" ]"#,
+        single_assertion_envelope.short_id(DigestDisplayFormat::Short)
+    );
+    assert_actual_expected!(format_paths(&paths), expected);
+}
+
+#[test]
+fn test_obscured_pattern() {
+    let original_envelope = Envelope::new("Secret data");
+
+    // Test with elided envelope
+    let elided_envelope = original_envelope.elide();
+    assert!(Pattern::obscured().matches(&elided_envelope));
+    assert!(Pattern::elided().matches(&elided_envelope));
+    assert!(!Pattern::encrypted().matches(&elided_envelope));
+    assert!(!Pattern::compressed().matches(&elided_envelope));
+
+    // Test with original (non-obscured) envelope
+    assert!(!Pattern::obscured().matches(&original_envelope));
+    assert!(!Pattern::elided().matches(&original_envelope));
+    assert!(!Pattern::encrypted().matches(&original_envelope));
+    assert!(!Pattern::compressed().matches(&original_envelope));
+
+    // Test paths for elided envelope
+    let paths = Pattern::elided().paths(&elided_envelope);
+    #[rustfmt::skip]
+    let expected = format!(
+        "{} ELIDED",
+        elided_envelope.short_id(DigestDisplayFormat::Short)
+    );
+    assert_actual_expected!(format_paths(&paths), expected);
+
+    // No match should return empty paths
+    let paths = Pattern::elided().paths(&original_envelope);
+    assert!(paths.is_empty());
+
+    #[cfg(feature = "encrypt")]
+    {
+        use bc_components::SymmetricKey;
+
+        // Test with encrypted envelope
+        let key = SymmetricKey::new();
+        let encrypted_envelope =
+            original_envelope.encrypt_subject(&key).unwrap();
+        assert!(Pattern::obscured().matches(&encrypted_envelope));
+        assert!(Pattern::encrypted().matches(&encrypted_envelope));
+        assert!(!Pattern::elided().matches(&encrypted_envelope));
+        assert!(!Pattern::compressed().matches(&encrypted_envelope));
+    }
+
+    #[cfg(feature = "compress")]
+    {
+        // Test with compressed envelope
+        let compressed_envelope = original_envelope.compress().unwrap();
+        assert!(Pattern::obscured().matches(&compressed_envelope));
+        assert!(Pattern::compressed().matches(&compressed_envelope));
+        assert!(!Pattern::elided().matches(&compressed_envelope));
+        assert!(!Pattern::encrypted().matches(&compressed_envelope));
+    }
+}


### PR DESCRIPTION
## Summary
- add new `bc-envelope-pattern` crate containing the pattern subsystem
- expose Envelope types from `bc-envelope` inside the new crate
- copy pattern tests and utilities so the new crate is verified independently

## Testing
- `cargo test` in `bc-envelope-pattern`

------
https://chatgpt.com/codex/tasks/task_e_684ff6f29ca8832582e015288ae4936d